### PR TITLE
Phase 10.1: Workspace UI for multi-tenancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 [![Deploy](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml/badge.svg)](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml)
 ![.NET](https://img.shields.io/badge/.NET-8.0-512BD4?style=flat&logo=dotnet)
 ![C#](https://img.shields.io/badge/C%23-12-239120?style=flat&logo=csharp)
-![Tests](https://img.shields.io/badge/tests-265%20passing-brightgreen)
-![Phase](https://img.shields.io/badge/phase-10%20Multi--tenancy%20complete-brightgreen)
+![Tests](https://img.shields.io/badge/tests-273%20passing-brightgreen)
+![Phase](https://img.shields.io/badge/phase-10.1%20Workspace%20UI%20complete-brightgreen)
 ![License](https://img.shields.io/badge/License-MIT-green.svg)
 
 ---
@@ -52,9 +52,17 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 ### Multi-tenancy / Workspaces ✅
 - **Isolated workspaces** — Each workspace has its own Qdrant collection + scoped PostgreSQL rows; zero cross-tenant data leakage
 - **Per-workspace API keys** — 32-byte random hex key; SHA-256 hash stored; plaintext shown once on creation
-- **Workspace CRUD** — `POST /api/workspaces` (create), `GET /api/workspaces/{id}` (get), `DELETE /api/workspaces/{id}` (cascade delete)
+- **Workspace CRUD** — `POST /api/workspaces` (create), `GET /api/workspaces/{id}` (get), `GET /api/workspaces/current` (resolve from key), `DELETE /api/workspaces/{id}` (cascade delete)
 - **Cascade delete** — Deleting a workspace removes its Qdrant collection, all documents, and all conversations atomically
 - **Backward compatibility** — Default workspace (`documents` collection) maps to the global `ApiAuth:ApiKey` config key
+
+### Workspace UI ✅
+- **Workspaces page** — Create, switch, delete, and import workspaces from `/workspaces`
+- **Navbar chip** — Active workspace shown as indigo pill in the top navigation bar
+- **Per-workspace chat history** — localStorage conversation list scoped by workspace ID; switches automatically on workspace change
+- **API key modal** — One-time display with clipboard copy; Done button re-enabled after 10 s if clipboard is blocked
+- **Import flow** — Paste an existing API key to link a workspace to this browser session (validates via `GET /api/documents`, resolves ID via `GET /api/workspaces/current`)
+- **Dynamic key injection** — `WorkspaceKeyHandler` DelegatingHandler replaces the static `X-Api-Key` header on every outgoing request
 
 ### Security & Reliability
 - **API key authentication** — Protect all endpoints via `X-Api-Key` header; resolves workspace from DB hash lookup
@@ -74,7 +82,7 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 - **GitHub Actions CI/CD** — Automated test, build, and deploy pipeline
 - **Azure deployment** — Container Apps (scales to zero) + Static Web Apps (free tier)
 - **Modern SaaS UI ✅** — Inter design system, indigo theme, drag-drop uploads, glassmorphism health dashboard, footer
-- **265 unit tests** — xUnit + Moq + FluentAssertions across all layers
+- **273 unit tests** — xUnit + Moq + FluentAssertions across all layers
 
 ---
 
@@ -177,6 +185,7 @@ curl http://localhost:5000/api/system/health
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `POST` | `/api/workspaces` | Create workspace; returns plaintext API key (shown once) |
+| `GET` | `/api/workspaces/current` | Resolve current workspace from X-Api-Key header |
 | `GET` | `/api/workspaces/{id}` | Get workspace metadata |
 | `DELETE` | `/api/workspaces/{id}` | Cascade delete workspace, documents, and vector data |
 
@@ -287,7 +296,7 @@ Cors__AllowedOrigins__0=https://your-frontend.azurestaticapps.net
 | **Frontend** | Blazor WebAssembly (.NET 8) — Inter design system, indigo theme |
 | **Hosting** | Azure Container Apps + Azure Static Web Apps |
 | **CI/CD** | GitHub Actions → GHCR → Azure |
-| **Testing** | xUnit, Moq, FluentAssertions (265 tests) |
+| **Testing** | xUnit, Moq, FluentAssertions (273 tests) |
 | **API Docs** | Swagger / OpenAPI |
 
 ---
@@ -303,7 +312,7 @@ dotnet-rag-api/
 │   ├── RagApi.Domain/           # Core entities
 │   └── RagApi.Infrastructure/   # Qdrant, OpenAI, Azure, EF Core
 ├── tests/
-│   └── RagApi.Tests/            # 265 unit tests
+│   └── RagApi.Tests/            # 273 unit tests
 ├── .github/workflows/           # CI, Deploy API, Deploy UI
 ├── docker-compose.yml           # Local Qdrant + Ollama + PostgreSQL
 ├── Dockerfile                   # Production container image

--- a/src/RagApi.Api/Controllers/WorkspacesController.cs
+++ b/src/RagApi.Api/Controllers/WorkspacesController.cs
@@ -48,6 +48,19 @@ public class WorkspacesController : ControllerBase
     }
 
     /// <summary>
+    /// Returns the workspace resolved from the caller's X-Api-Key header.
+    /// Used by the UI import flow to resolve workspace ID and name from a raw key.
+    /// </summary>
+    // Argha - 2026-03-04 - #17 - Needed by Blazor import flow: resolve workspace from key without knowing ID
+    [HttpGet("current")]
+    [ProducesResponseType(typeof(WorkspaceDto), StatusCodes.Status200OK)]
+    public IActionResult GetCurrentWorkspace()
+    {
+        var ws = _workspaceContext.Current;
+        return Ok(new WorkspaceDto(ws.Id, ws.Name, ws.CreatedAt, ws.CollectionName));
+    }
+
+    /// <summary>
     /// Get workspace metadata by ID (API key is not returned).
     /// </summary>
     [HttpGet("{id:guid}")]

--- a/src/RagApi.BlazorUI/Layout/NavMenu.razor
+++ b/src/RagApi.BlazorUI/Layout/NavMenu.razor
@@ -1,6 +1,9 @@
 @* Argha - 2026-03-03 - #12 - Redesigned navigation: white navbar, SVG icons, pill nav items *@
+@* Argha - 2026-03-04 - #17 - Added Workspaces link and active workspace chip *@
 @* Argha - 2026-02-21 - Commented: old Bootstrap dark navbar *@
 @* <nav class="navbar navbar-expand-lg navbar-dark bg-dark"> *@
+@inject WorkspaceStateService WsState
+@implements IDisposable
 
 <nav class="navbar navbar-modern navbar-expand-lg">
     <div class="container-fluid">
@@ -44,6 +47,15 @@
                     </NavLink>
                 </li>
                 <li class="nav-item">
+                    <NavLink class="nav-link-modern" href="/workspaces" ActiveClass="active">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>
+                            <rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/>
+                        </svg>
+                        Workspaces
+                    </NavLink>
+                </li>
+                <li class="nav-item">
                     <NavLink class="nav-link-modern" href="/health" ActiveClass="active">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
@@ -52,6 +64,36 @@
                     </NavLink>
                 </li>
             </ul>
+
+            @* Argha - 2026-03-04 - #17 - Active workspace chip shown on right end of navbar *@
+            @if (WsState.Active != null)
+            {
+                <div class="ms-auto me-3">
+                    <a href="/workspaces" class="workspace-chip" style="text-decoration:none;">
+                        <span class="ws-dot"></span>
+                        @WsState.Active.Name
+                    </a>
+                </div>
+            }
         </div>
     </div>
 </nav>
+
+@code {
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            WsState.OnChanged += OnWorkspaceChanged;
+            await WsState.InitializeAsync();
+            StateHasChanged();
+        }
+    }
+
+    public void Dispose()
+    {
+        WsState.OnChanged -= OnWorkspaceChanged;
+    }
+
+    private void OnWorkspaceChanged() => InvokeAsync(StateHasChanged);
+}

--- a/src/RagApi.BlazorUI/Models/WorkspaceModels.cs
+++ b/src/RagApi.BlazorUI/Models/WorkspaceModels.cs
@@ -1,0 +1,15 @@
+namespace RagApi.BlazorUI.Models;
+
+// Argha - 2026-03-04 - #17 - Workspace UI models: mirrors API DTOs + local storage structure
+
+public record WorkspaceDto(Guid Id, string Name, DateTime CreatedAt, string CollectionName);
+
+public record WorkspaceCreatedDto(Guid Id, string Name, DateTime CreatedAt, string CollectionName, string ApiKey);
+
+public class StoredWorkspace
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string ApiKey { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/RagApi.BlazorUI/Pages/Chat.razor
+++ b/src/RagApi.BlazorUI/Pages/Chat.razor
@@ -1,9 +1,11 @@
 @* Argha - 2026-03-03 - #13 - Chat page redesign: modern sidebar, indigo bubbles, improved input & sources *@
+@* Argha - 2026-03-04 - #17 - Scoped conversation list per workspace; reload on workspace switch *@
 @* Argha - 2026-02-21 - Original chat page: sidebar with conversation list + streaming message panel *@
 @page "/"
 @inject ChatApiService ChatService
 @inject ConversationApiService ConversationService
 @inject LocalStorageService LocalStorage
+@inject WorkspaceStateService WsState
 @implements IAsyncDisposable
 
 <PageTitle>Chat — RAG Chat</PageTitle>
@@ -174,7 +176,7 @@
 </div>
 
 @code {
-    // ── Conversation list (IDs persisted in localStorage) ──
+    // ── Conversation list (IDs persisted in localStorage per workspace) ──
     private List<StoredConversation> _conversations = new();
     private Guid _activeConvId = Guid.Empty;
 
@@ -189,10 +191,41 @@
     private ElementReference _messagesContainer;
     private CancellationTokenSource? _streamCts;
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
-        // Argha - 2026-02-21 - Restore stored conversations from localStorage on page load
-        var stored = await LocalStorage.GetItemAsync<List<StoredConversation>>("rag_conversations");
+        // Argha - 2026-03-04 - #17 - Subscribe early so workspace switches reload conversation list
+        WsState.OnChanged += OnWorkspaceChanged;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            // Argha - 2026-03-04 - #17 - Ensure workspace state loaded before reading active workspace key
+            await WsState.InitializeAsync();
+            await LoadConversationsAsync();
+            StateHasChanged();
+        }
+    }
+
+    // Argha - 2026-03-04 - #17 - Reload conversation list from new workspace key when active workspace changes
+    private void OnWorkspaceChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            _conversations = new();
+            _activeConvId = Guid.Empty;
+            _messages = new();
+            await LoadConversationsAsync();
+            StateHasChanged();
+        });
+    }
+
+    // Argha - 2026-03-04 - #17 - Conversation list scoped per workspace: key = rag_conversations_{workspaceId}
+    private async Task LoadConversationsAsync()
+    {
+        var key = $"rag_conversations_{WsState.Active?.Id ?? Guid.Empty}";
+        var stored = await LocalStorage.GetItemAsync<List<StoredConversation>>(key);
         _conversations = stored ?? new List<StoredConversation>();
 
         if (_conversations.Count > 0)
@@ -324,13 +357,16 @@
             await SendMessageAsync();
     }
 
+    // Argha - 2026-03-04 - #17 - localStorage key scoped to active workspace so conversations are isolated per workspace
     private async Task PersistConversationsAsync()
     {
-        await LocalStorage.SetItemAsync("rag_conversations", _conversations);
+        var key = $"rag_conversations_{WsState.Active?.Id ?? Guid.Empty}";
+        await LocalStorage.SetItemAsync(key, _conversations);
     }
 
     public async ValueTask DisposeAsync()
     {
+        WsState.OnChanged -= OnWorkspaceChanged;
         _streamCts?.Cancel();
         _streamCts?.Dispose();
         await ValueTask.CompletedTask;

--- a/src/RagApi.BlazorUI/Pages/Workspaces.razor
+++ b/src/RagApi.BlazorUI/Pages/Workspaces.razor
@@ -1,0 +1,456 @@
+@* Argha - 2026-03-04 - #17 - Workspace management page: create, switch, delete, import workspaces *@
+@page "/workspaces"
+@inject WorkspaceStateService WsState
+@inject WorkspaceApiService WsApi
+@inject IJSRuntime JS
+@implements IDisposable
+
+<PageTitle>Workspaces — RAG Chat</PageTitle>
+
+<div class="page-body-scroll">
+<div style="max-width:1100px;margin:0 auto;padding:var(--space-6) var(--space-4);">
+
+    @* ── Page header ── *@
+    <div class="section-header">
+        <div>
+            <h1 class="section-title">Workspaces</h1>
+            <p class="section-subtitle">Manage isolated data environments for different teams or clients</p>
+        </div>
+        <button class="btn-primary-modern" @onclick="ToggleCreateForm" disabled="@_isCreating">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+                <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+            </svg>
+            New Workspace
+        </button>
+    </div>
+
+    @* ── Inline create form ── *@
+    @if (_showCreateForm)
+    {
+        <div class="card-modern" style="margin-bottom:var(--space-5);">
+            <h3 style="font-size:var(--text-base);font-weight:var(--weight-semibold);color:var(--text-primary);margin:0 0 var(--space-4);">Create New Workspace</h3>
+            @if (!string.IsNullOrEmpty(_createError))
+            {
+                <div class="alert-modern alert-danger" style="margin-bottom:var(--space-3);">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="flex-shrink:0;">
+                        <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+                    </svg>
+                    @_createError
+                </div>
+            }
+            <div style="display:flex;gap:var(--space-3);align-items:flex-end;">
+                <div style="flex:1;">
+                    <label style="font-size:var(--text-xs);font-weight:var(--weight-medium);color:var(--text-secondary);display:block;margin-bottom:var(--space-1);">Workspace Name</label>
+                    <input type="text" class="input-modern" placeholder="e.g. Acme Corp, Beta Team"
+                           @bind="_createName" @bind:event="oninput"
+                           @onkeydown="HandleCreateKeyDown" />
+                </div>
+                <button class="btn-primary-modern" @onclick="CreateWorkspaceAsync"
+                        disabled="@(_isCreating || string.IsNullOrWhiteSpace(_createName))">
+                    @if (_isCreating)
+                    {
+                        <div class="spinner-sm"></div>
+                        <span>Creating…</span>
+                    }
+                    else
+                    {
+                        <span>Create</span>
+                    }
+                </button>
+                <button class="btn-ghost" @onclick="CancelCreate">Cancel</button>
+            </div>
+        </div>
+    }
+
+    @* ── Workspace cards ── *@
+    @if (WsState.Workspaces.Count == 0)
+    {
+        <div class="card-modern" style="margin-bottom:var(--space-5);">
+            <div class="empty-state" style="padding:var(--space-10) var(--space-8);">
+                <div class="empty-state-icon">
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                        <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>
+                        <rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/>
+                    </svg>
+                </div>
+                <h3>No workspaces yet</h3>
+                <p>Create your first workspace to start isolating data per team or client.</p>
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="ws-card-grid" style="margin-bottom:var(--space-6);">
+            @foreach (var ws in WsState.Workspaces)
+            {
+                var isActive = WsState.Active?.Id == ws.Id;
+                var isConfirmingDelete = _confirmDeleteId == ws.Id;
+                var isDeleting = _deletingId == ws.Id;
+                <div class="card-modern @(isActive ? "ws-card-active" : "")">
+                    <div style="margin-bottom:var(--space-3);">
+                        @if (isActive)
+                        {
+                            <span class="status-badge status-success" style="margin-bottom:var(--space-2);display:inline-flex;">Active</span>
+                        }
+                        <h3 class="ws-card-name">@ws.Name</h3>
+                        <p class="ws-card-date">Created @ws.CreatedAt.ToLocalTime().ToString("MMM d, yyyy")</p>
+                    </div>
+                    <div style="display:flex;gap:var(--space-2);flex-wrap:wrap;align-items:center;">
+                        @if (!isActive)
+                        {
+                            <button class="btn-ghost" style="font-size:var(--text-sm);"
+                                    @onclick="() => SwitchWorkspaceAsync(ws.Id)"
+                                    disabled="@_isSwitching">
+                                Switch
+                            </button>
+                        }
+                        @if (isConfirmingDelete)
+                        {
+                            <button class="btn-confirm-danger" @onclick="() => ConfirmDeleteAsync(ws.Id)">
+                                Confirm?
+                            </button>
+                        }
+                        else
+                        {
+                            <button class="btn-icon btn-icon-danger" title="Delete workspace"
+                                    @onclick="() => InitiateDelete(ws.Id)"
+                                    disabled="@isDeleting">
+                                @if (isDeleting)
+                                {
+                                    <div class="spinner-sm spinner-dark"></div>
+                                }
+                                else
+                                {
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+                                        <polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/>
+                                        <path d="M10 11v6M14 11v6M9 6V4h6v2"/>
+                                    </svg>
+                                }
+                            </button>
+                        }
+                    </div>
+                    @if (!string.IsNullOrEmpty(_deleteError) && isConfirmingDelete)
+                    {
+                        <div class="alert-modern alert-danger" style="margin-top:var(--space-2);">@_deleteError</div>
+                    }
+                </div>
+            }
+        </div>
+    }
+
+    @* ── Import existing workspace ── *@
+    <div class="card-modern">
+        <h3 style="font-size:var(--text-base);font-weight:var(--weight-semibold);color:var(--text-primary);margin:0 0 var(--space-1);">Import Existing Workspace</h3>
+        <p style="font-size:var(--text-sm);color:var(--text-muted);margin:0 0 var(--space-4);">Already have an API key? Add the workspace to this browser session.</p>
+        @if (!string.IsNullOrEmpty(_importError))
+        {
+            <div class="alert-modern alert-danger" style="margin-bottom:var(--space-3);">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="flex-shrink:0;">
+                    <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+                </svg>
+                @_importError
+            </div>
+        }
+        <div style="display:flex;gap:var(--space-3);align-items:flex-end;flex-wrap:wrap;">
+            <div style="flex:1;min-width:150px;">
+                <label style="font-size:var(--text-xs);font-weight:var(--weight-medium);color:var(--text-secondary);display:block;margin-bottom:var(--space-1);">Display Name</label>
+                <input type="text" class="input-modern" placeholder="e.g. Acme Corp"
+                       @bind="_importName" @bind:event="oninput" />
+            </div>
+            <div style="flex:2;min-width:200px;">
+                <label style="font-size:var(--text-xs);font-weight:var(--weight-medium);color:var(--text-secondary);display:block;margin-bottom:var(--space-1);">API Key</label>
+                <input type="password" class="input-modern" placeholder="Paste your workspace API key"
+                       @bind="_importKey" @bind:event="oninput" />
+            </div>
+            <button class="btn-primary-modern" @onclick="ImportWorkspaceAsync"
+                    disabled="@(_isImporting || string.IsNullOrWhiteSpace(_importName) || string.IsNullOrWhiteSpace(_importKey))">
+                @if (_isImporting)
+                {
+                    <div class="spinner-sm"></div>
+                    <span>Validating…</span>
+                }
+                else
+                {
+                    <span>Add</span>
+                }
+            </button>
+        </div>
+    </div>
+
+</div>
+</div>
+
+@* ── API Key Modal ── *@
+@if (_showKeyModal)
+{
+    <div class="workspace-modal-overlay">
+        <div class="workspace-modal">
+            <h2 style="font-size:var(--text-lg);font-weight:var(--weight-semibold);color:var(--text-primary);margin:0 0 var(--space-1);">
+                Workspace Created
+            </h2>
+            <p style="font-size:var(--text-sm);color:var(--text-muted);margin:0 0 var(--space-4);">@_newWorkspaceName</p>
+            <div style="height:1px;background:var(--border);margin-bottom:var(--space-4);"></div>
+            <div class="alert-modern alert-info" style="margin-bottom:var(--space-4);">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="flex-shrink:0;">
+                    <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+                    <line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
+                </svg>
+                Save this key — it won't be shown again
+            </div>
+            <div class="api-key-box">
+                <span class="api-key-text">@_newApiKey</span>
+                <button class="btn-ghost api-key-copy-btn" @onclick="CopyKeyAsync" title="Copy to clipboard">
+                    @if (_keyCopied)
+                    {
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+                            <polyline points="20 6 9 17 4 12"/>
+                        </svg>
+                        <span>Copied!</span>
+                    }
+                    else
+                    {
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+                            <rect x="9" y="9" width="13" height="13" rx="2"/>
+                            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                        </svg>
+                        <span>Copy</span>
+                    }
+                </button>
+            </div>
+            <button class="btn-primary-modern w-100" style="margin-top:var(--space-5);"
+                    @onclick="DismissModal"
+                    disabled="@(!_keyCopied && !_doneButtonEnabled)">
+                Done — I saved it
+            </button>
+        </div>
+    </div>
+}
+
+@code {
+    // ── Create state ──
+    private bool _showCreateForm;
+    private string _createName = string.Empty;
+    private bool _isCreating;
+    private string _createError = string.Empty;
+
+    // ── Modal state ──
+    private bool _showKeyModal;
+    private string _newWorkspaceName = string.Empty;
+    private string _newApiKey = string.Empty;
+    private bool _keyCopied;
+    private bool _doneButtonEnabled;
+    private StoredWorkspace? _pendingWorkspace;
+
+    // ── Delete state ──
+    private Guid? _confirmDeleteId;
+    private Guid? _deletingId;
+    private string _deleteError = string.Empty;
+
+    // ── Switch state ──
+    private bool _isSwitching;
+
+    // ── Import state ──
+    private string _importName = string.Empty;
+    private string _importKey = string.Empty;
+    private bool _isImporting;
+    private string _importError = string.Empty;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            WsState.OnChanged += OnWorkspaceChanged;
+            await WsState.InitializeAsync();
+            StateHasChanged();
+        }
+    }
+
+    public void Dispose()
+    {
+        WsState.OnChanged -= OnWorkspaceChanged;
+    }
+
+    private void OnWorkspaceChanged() => InvokeAsync(StateHasChanged);
+
+    private void ToggleCreateForm()
+    {
+        _showCreateForm = !_showCreateForm;
+        _createName = string.Empty;
+        _createError = string.Empty;
+    }
+
+    private void CancelCreate()
+    {
+        _showCreateForm = false;
+        _createName = string.Empty;
+        _createError = string.Empty;
+    }
+
+    private async Task HandleCreateKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter" && !string.IsNullOrWhiteSpace(_createName))
+            await CreateWorkspaceAsync();
+    }
+
+    private async Task CreateWorkspaceAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_createName) || _isCreating) return;
+        _isCreating = true;
+        _createError = string.Empty;
+
+        try
+        {
+            var created = await WsApi.CreateAsync(_createName.Trim());
+
+            _newWorkspaceName = created.Name;
+            _newApiKey = created.ApiKey;
+            _keyCopied = false;
+            _doneButtonEnabled = false;
+            _showKeyModal = true;
+            _showCreateForm = false;
+            _createName = string.Empty;
+
+            _pendingWorkspace = new StoredWorkspace
+            {
+                Id = created.Id,
+                Name = created.Name,
+                ApiKey = created.ApiKey,
+                CreatedAt = created.CreatedAt
+            };
+
+            // Argha - 2026-03-04 - #17 - Re-enable Done button after 10s even if key not copied
+            _ = Task.Delay(10_000).ContinueWith(_ =>
+                InvokeAsync(() => { _doneButtonEnabled = true; StateHasChanged(); }));
+        }
+        catch (Exception ex)
+        {
+            _createError = $"Failed to create workspace: {ex.Message}";
+        }
+        finally
+        {
+            _isCreating = false;
+        }
+    }
+
+    private async Task CopyKeyAsync()
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("navigator.clipboard.writeText", _newApiKey);
+        }
+        catch
+        {
+            // Best effort — clipboard API unavailable in some contexts
+        }
+        _keyCopied = true;
+    }
+
+    private async Task DismissModal()
+    {
+        _showKeyModal = false;
+        if (_pendingWorkspace != null)
+        {
+            await WsState.AddWorkspaceAsync(_pendingWorkspace);
+            await WsState.SetActiveAsync(_pendingWorkspace.Id);
+            _pendingWorkspace = null;
+        }
+    }
+
+    private async Task SwitchWorkspaceAsync(Guid id)
+    {
+        _isSwitching = true;
+        try
+        {
+            await WsState.SetActiveAsync(id);
+        }
+        finally
+        {
+            _isSwitching = false;
+        }
+    }
+
+    private void InitiateDelete(Guid id)
+    {
+        _confirmDeleteId = id;
+        _deleteError = string.Empty;
+
+        // Argha - 2026-03-04 - #17 - Auto-cancel confirm state after 3s if not acted upon
+        _ = Task.Delay(3_000).ContinueWith(_ => InvokeAsync(() =>
+        {
+            if (_confirmDeleteId == id)
+            {
+                _confirmDeleteId = null;
+                StateHasChanged();
+            }
+        }));
+    }
+
+    private async Task ConfirmDeleteAsync(Guid id)
+    {
+        _confirmDeleteId = null;
+        _deletingId = id;
+        _deleteError = string.Empty;
+
+        try
+        {
+            await WsApi.DeleteAsync(id);
+            await WsState.RemoveWorkspaceAsync(id);
+        }
+        catch (Exception ex)
+        {
+            _deleteError = $"Failed to delete: {ex.Message}";
+        }
+        finally
+        {
+            _deletingId = null;
+        }
+    }
+
+    private async Task ImportWorkspaceAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_importName) || string.IsNullOrWhiteSpace(_importKey) || _isImporting) return;
+        _isImporting = true;
+        _importError = string.Empty;
+
+        try
+        {
+            var keyTrimmed = _importKey.Trim();
+
+            // Argha - 2026-03-04 - #17 - Validate key explicitly; passes key directly to bypass active-key injection
+            var isValid = await WsApi.ValidateKeyAsync(keyTrimmed);
+            if (!isValid)
+            {
+                _importError = "Invalid API key — check it and try again.";
+                return;
+            }
+
+            var current = await WsApi.GetCurrentAsync(keyTrimmed);
+            if (current == null)
+            {
+                _importError = "Could not resolve workspace from this key.";
+                return;
+            }
+
+            var ws = new StoredWorkspace
+            {
+                Id = current.Id,
+                Name = _importName.Trim(),
+                ApiKey = keyTrimmed,
+                CreatedAt = current.CreatedAt
+            };
+
+            await WsState.AddWorkspaceAsync(ws);
+            await WsState.SetActiveAsync(ws.Id);
+            _importName = string.Empty;
+            _importKey = string.Empty;
+        }
+        catch (Exception ex)
+        {
+            _importError = $"Import failed: {ex.Message}";
+        }
+        finally
+        {
+            _isImporting = false;
+        }
+    }
+}

--- a/src/RagApi.BlazorUI/Program.cs
+++ b/src/RagApi.BlazorUI/Program.cs
@@ -7,21 +7,28 @@ var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
-// Argha - 2026-02-21 - Configure HttpClient with API base URL and optional API key from wwwroot/appsettings.json 
+// Argha - 2026-03-04 - #17 - Read API base URL; static ApiKey kept for backward-compat seeding in WorkspaceStateService
 var apiBaseUrl = builder.Configuration["ApiBaseUrl"] ?? "http://localhost:5000";
-var apiKey = builder.Configuration["ApiKey"] ?? string.Empty;
 
+// Argha - 2026-03-04 - #17 - WorkspaceStateService: Singleton; persists workspace list + active selection to localStorage
+builder.Services.AddSingleton<WorkspaceStateService>();
+
+// Argha - 2026-03-04 - #17 - WorkspaceKeyHandler: Transient DelegatingHandler; injects X-Api-Key from active workspace
+builder.Services.AddTransient<WorkspaceKeyHandler>();
+
+// Argha - 2026-03-04 - #17 - HttpClient wired through WorkspaceKeyHandler for dynamic key injection on every request
+// Static X-Api-Key default header removed; key now injected per-request via handler
 builder.Services.AddScoped(sp =>
 {
-    var client = new HttpClient { BaseAddress = new Uri(apiBaseUrl) };
-    if (!string.IsNullOrWhiteSpace(apiKey))
-        client.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
-    return client;
+    var handler = sp.GetRequiredService<WorkspaceKeyHandler>();
+    handler.InnerHandler = new HttpClientHandler();
+    return new HttpClient(handler) { BaseAddress = new Uri(apiBaseUrl) };
 });
 
 builder.Services.AddScoped<LocalStorageService>();
 builder.Services.AddScoped<ChatApiService>();
 builder.Services.AddScoped<DocumentApiService>();
 builder.Services.AddScoped<ConversationApiService>();
+builder.Services.AddScoped<WorkspaceApiService>();
 
 await builder.Build().RunAsync();

--- a/src/RagApi.BlazorUI/Services/WorkspaceApiService.cs
+++ b/src/RagApi.BlazorUI/Services/WorkspaceApiService.cs
@@ -1,0 +1,67 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using RagApi.BlazorUI.Models;
+
+namespace RagApi.BlazorUI.Services;
+
+// Argha - 2026-03-04 - #17 - HTTP client for /api/workspaces endpoints
+public class WorkspaceApiService
+{
+    private readonly HttpClient _http;
+    private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+
+    public WorkspaceApiService(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<WorkspaceCreatedDto> CreateAsync(string name, CancellationToken ct = default)
+    {
+        var response = await _http.PostAsJsonAsync("/api/workspaces", new { Name = name }, _jsonOptions, ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<WorkspaceCreatedDto>(_jsonOptions, ct)
+            ?? throw new InvalidOperationException("Empty response from /api/workspaces");
+    }
+
+    // Argha - 2026-03-04 - #17 - Optional apiKey param: when set, bypasses WorkspaceKeyHandler (import flow)
+    public async Task<WorkspaceDto?> GetCurrentAsync(string? apiKey = null, CancellationToken ct = default)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/workspaces/current");
+        if (!string.IsNullOrEmpty(apiKey))
+            request.Headers.Add("X-Api-Key", apiKey);
+        try
+        {
+            var response = await _http.SendAsync(request, ct);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<WorkspaceDto>(_jsonOptions, ct);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken ct = default)
+    {
+        var response = await _http.DeleteAsync($"/api/workspaces/{id}", ct);
+        response.EnsureSuccessStatusCode();
+    }
+
+    // Argha - 2026-03-04 - #17 - Validates key by calling GET /api/documents; 401 = invalid key
+    // Optional apiKey param bypasses WorkspaceKeyHandler for import validation
+    public async Task<bool> ValidateKeyAsync(string? apiKey = null, CancellationToken ct = default)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/documents");
+        if (!string.IsNullOrEmpty(apiKey))
+            request.Headers.Add("X-Api-Key", apiKey);
+        try
+        {
+            var response = await _http.SendAsync(request, ct);
+            return response.StatusCode != System.Net.HttpStatusCode.Unauthorized;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/RagApi.BlazorUI/Services/WorkspaceKeyHandler.cs
+++ b/src/RagApi.BlazorUI/Services/WorkspaceKeyHandler.cs
@@ -1,0 +1,24 @@
+namespace RagApi.BlazorUI.Services;
+
+// Argha - 2026-03-04 - #17 - DelegatingHandler: injects X-Api-Key from the active workspace on every outgoing request
+// Does not override if the request already carries the header (allows per-request override for import validation)
+public class WorkspaceKeyHandler : DelegatingHandler
+{
+    private readonly WorkspaceStateService _wsState;
+
+    public WorkspaceKeyHandler(WorkspaceStateService wsState)
+    {
+        _wsState = wsState;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+    {
+        if (!request.Headers.Contains("X-Api-Key"))
+        {
+            var key = _wsState.ApiKey;
+            if (!string.IsNullOrEmpty(key))
+                request.Headers.Add("X-Api-Key", key);
+        }
+        return base.SendAsync(request, ct);
+    }
+}

--- a/src/RagApi.BlazorUI/Services/WorkspaceStateService.cs
+++ b/src/RagApi.BlazorUI/Services/WorkspaceStateService.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.JSInterop;
+using System.Text.Json;
+using RagApi.BlazorUI.Models;
+
+namespace RagApi.BlazorUI.Services;
+
+// Argha - 2026-03-04 - #17 - Singleton state manager for workspace selection; persists to localStorage
+public class WorkspaceStateService
+{
+    private readonly IJSRuntime _js;
+    private readonly string _fallbackApiKey;
+    private static readonly JsonSerializerOptions _options = new(JsonSerializerDefaults.Web);
+
+    private List<StoredWorkspace> _workspaces = new();
+    private Guid? _activeId;
+    private bool _initialized;
+
+    public IReadOnlyList<StoredWorkspace> Workspaces => _workspaces;
+
+    public StoredWorkspace? Active => _activeId.HasValue
+        ? _workspaces.FirstOrDefault(w => w.Id == _activeId)
+        : null;
+
+    // Argha - 2026-03-04 - #17 - Consumed by WorkspaceKeyHandler on every outgoing request
+    public string ApiKey => Active?.ApiKey ?? string.Empty;
+
+    public event Action? OnChanged;
+
+    public WorkspaceStateService(IJSRuntime js, IConfiguration config)
+    {
+        _js = js;
+        _fallbackApiKey = config["ApiKey"] ?? string.Empty;
+    }
+
+    // Argha - 2026-03-04 - #17 - Idempotent: safe to call from multiple components; only loads once
+    public async Task InitializeAsync()
+    {
+        if (_initialized) return;
+        _initialized = true;
+
+        var storedJson = await _js.InvokeAsync<string?>("localStorage.getItem", "rag_workspaces");
+        if (!string.IsNullOrEmpty(storedJson))
+            _workspaces = JsonSerializer.Deserialize<List<StoredWorkspace>>(storedJson, _options) ?? new();
+
+        var activeIdStr = await _js.InvokeAsync<string?>("localStorage.getItem", "rag_active_workspace_id");
+        if (Guid.TryParse(activeIdStr, out var id))
+            _activeId = id;
+
+        // Argha - 2026-03-04 - #17 - Backward compat: seed default workspace from appsettings ApiKey on first launch
+        if (_workspaces.Count == 0 && !string.IsNullOrEmpty(_fallbackApiKey))
+        {
+            var defaultWs = new StoredWorkspace
+            {
+                Id = Guid.NewGuid(),
+                Name = "Default",
+                ApiKey = _fallbackApiKey,
+                CreatedAt = DateTime.UtcNow
+            };
+            _workspaces.Add(defaultWs);
+            _activeId = defaultWs.Id;
+            await PersistAsync();
+        }
+    }
+
+    public async Task AddWorkspaceAsync(StoredWorkspace ws)
+    {
+        _workspaces.Add(ws);
+        await PersistAsync();
+        OnChanged?.Invoke();
+    }
+
+    public async Task SetActiveAsync(Guid id)
+    {
+        _activeId = id;
+        await PersistAsync();
+        OnChanged?.Invoke();
+    }
+
+    public async Task RemoveWorkspaceAsync(Guid id)
+    {
+        _workspaces.RemoveAll(w => w.Id == id);
+        if (_activeId == id)
+            _activeId = null;
+        await PersistAsync();
+        OnChanged?.Invoke();
+    }
+
+    private async Task PersistAsync()
+    {
+        var json = JsonSerializer.Serialize(_workspaces, _options);
+        await _js.InvokeVoidAsync("localStorage.setItem", "rag_workspaces", json);
+
+        if (_activeId.HasValue)
+            await _js.InvokeVoidAsync("localStorage.setItem", "rag_active_workspace_id", _activeId.Value.ToString());
+        else
+            await _js.InvokeVoidAsync("localStorage.removeItem", "rag_active_workspace_id");
+    }
+}

--- a/src/RagApi.BlazorUI/wwwroot/css/components.css
+++ b/src/RagApi.BlazorUI/wwwroot/css/components.css
@@ -304,6 +304,128 @@
   line-height: 1.5;
 }
 
+/* ─── Workspace UI ───────────────────────────────────────────────────── */
+/* Argha - 2026-03-04 - #17 - Styles for workspace chip, modal, cards, and danger confirm */
+
+.workspace-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  background: var(--primary-light);
+  border: 1px solid var(--primary-mid);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--primary-hover);
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+.workspace-chip:hover {
+  background: var(--primary-mid);
+}
+
+.ws-dot {
+  width: 6px;
+  height: 6px;
+  background: var(--primary);
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.workspace-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.workspace-modal {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-6);
+  max-width: 480px;
+  width: 90%;
+}
+
+.api-key-box {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+}
+
+.api-key-text {
+  flex: 1;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.api-key-copy-btn {
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  gap: 4px;
+}
+
+.btn-confirm-danger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--danger-light);
+  color: var(--danger-text);
+  border: 1px solid #fca5a5;
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+.btn-confirm-danger:hover {
+  background: var(--danger);
+  color: white;
+  border-color: var(--danger);
+}
+
+.ws-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-4);
+}
+
+.ws-card-active {
+  border-color: var(--primary-mid);
+  background: var(--primary-light);
+}
+
+.ws-card-name {
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.ws-card-date {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  margin: 2px 0 0;
+}
+
 /* ─── Section header ─────────────────────────────────────────────────── */
 .section-header {
   display: flex;

--- a/tests/RagApi.Tests/Unit/BlazorUI/WorkspaceApiServiceTests.cs
+++ b/tests/RagApi.Tests/Unit/BlazorUI/WorkspaceApiServiceTests.cs
@@ -1,0 +1,76 @@
+// Argha - 2026-03-04 - #17 - Unit tests for WorkspaceApiService HTTP interactions
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Moq;
+using Moq.Protected;
+using RagApi.BlazorUI.Models;
+using RagApi.BlazorUI.Services;
+
+namespace RagApi.Tests.Unit.BlazorUI;
+
+public class WorkspaceApiServiceTests
+{
+    private static readonly JsonSerializerOptions _opts = new(JsonSerializerDefaults.Web);
+
+    private static (WorkspaceApiService sut, Mock<HttpMessageHandler> handler) BuildSut(
+        HttpStatusCode status, string body)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = status,
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://localhost:5000") };
+        return (new WorkspaceApiService(client), handler);
+    }
+
+    [Fact]
+    public async Task CreateAsync_PostsToWorkspacesEndpoint()
+    {
+        var created = new WorkspaceCreatedDto(Guid.NewGuid(), "Acme", DateTime.UtcNow, "ws_abc", "key123");
+        var (sut, handler) = BuildSut(HttpStatusCode.Created, JsonSerializer.Serialize(created, _opts));
+
+        var result = await sut.CreateAsync("Acme");
+
+        result.Name.Should().Be("Acme");
+        result.ApiKey.Should().Be("key123");
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(r =>
+                r.Method == HttpMethod.Post &&
+                r.RequestUri!.PathAndQuery == "/api/workspaces"),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_ReturnsWorkspaceDto()
+    {
+        var dto = new WorkspaceDto(Guid.NewGuid(), "Test Corp", DateTime.UtcNow, "ws_abc");
+        var (sut, _) = BuildSut(HttpStatusCode.OK, JsonSerializer.Serialize(dto, _opts));
+
+        var result = await sut.GetCurrentAsync();
+
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("Test Corp");
+    }
+
+    [Fact]
+    public async Task ValidateKeyAsync_ReturnsFalse_OnUnauthorized()
+    {
+        var (sut, _) = BuildSut(HttpStatusCode.Unauthorized, string.Empty);
+
+        var result = await sut.ValidateKeyAsync("bad-key");
+
+        result.Should().BeFalse();
+    }
+}

--- a/tests/RagApi.Tests/Unit/Services/WorkspaceStateServiceTests.cs
+++ b/tests/RagApi.Tests/Unit/Services/WorkspaceStateServiceTests.cs
@@ -1,0 +1,126 @@
+// Argha - 2026-03-04 - #17 - Unit tests for WorkspaceStateService: localStorage persistence and state management
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.JSInterop;
+using RagApi.BlazorUI.Models;
+using RagApi.BlazorUI.Services;
+using System.Text.Json;
+
+namespace RagApi.Tests.Unit.Services;
+
+public class WorkspaceStateServiceTests
+{
+    private static readonly JsonSerializerOptions _opts = new(JsonSerializerDefaults.Web);
+
+    private static WorkspaceStateService CreateSut(out FakeJSRuntime fakeJs, string? fallbackApiKey = null)
+    {
+        fakeJs = new FakeJSRuntime();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { { "ApiKey", fallbackApiKey ?? string.Empty } })
+            .Build();
+        return new WorkspaceStateService(fakeJs, config);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_LoadsFromLocalStorage()
+    {
+        var sut = CreateSut(out var fakeJs);
+        var stored = new List<StoredWorkspace>
+        {
+            new() { Id = Guid.NewGuid(), Name = "Acme", ApiKey = "key123", CreatedAt = DateTime.UtcNow }
+        };
+        fakeJs.SetItem("rag_workspaces", JsonSerializer.Serialize(stored, _opts));
+        fakeJs.SetItem("rag_active_workspace_id", stored[0].Id.ToString());
+
+        await sut.InitializeAsync();
+
+        sut.Workspaces.Should().HaveCount(1);
+        sut.Workspaces[0].Name.Should().Be("Acme");
+        sut.Active.Should().NotBeNull();
+        sut.Active!.Id.Should().Be(stored[0].Id);
+        sut.ApiKey.Should().Be("key123");
+    }
+
+    [Fact]
+    public async Task AddWorkspaceAsync_AppendsAndPersists()
+    {
+        var sut = CreateSut(out var fakeJs);
+        await sut.InitializeAsync();
+
+        var ws = new StoredWorkspace { Id = Guid.NewGuid(), Name = "New Corp", ApiKey = "k", CreatedAt = DateTime.UtcNow };
+        await sut.AddWorkspaceAsync(ws);
+
+        sut.Workspaces.Should().HaveCount(1);
+        sut.Workspaces[0].Name.Should().Be("New Corp");
+        fakeJs.GetItem("rag_workspaces").Should().Contain("New Corp");
+    }
+
+    [Fact]
+    public async Task SetActiveAsync_UpdatesActiveAndFiresEvent()
+    {
+        var sut = CreateSut(out _);
+        await sut.InitializeAsync();
+        var ws = new StoredWorkspace { Id = Guid.NewGuid(), Name = "Corp", ApiKey = "k", CreatedAt = DateTime.UtcNow };
+        await sut.AddWorkspaceAsync(ws);
+
+        bool eventFired = false;
+        sut.OnChanged += () => eventFired = true;
+        await sut.SetActiveAsync(ws.Id);
+
+        sut.Active.Should().NotBeNull();
+        sut.Active!.Id.Should().Be(ws.Id);
+        eventFired.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RemoveWorkspaceAsync_ClearsActiveWhenRemoved()
+    {
+        var sut = CreateSut(out _);
+        await sut.InitializeAsync();
+        var ws = new StoredWorkspace { Id = Guid.NewGuid(), Name = "ToDelete", ApiKey = "k", CreatedAt = DateTime.UtcNow };
+        await sut.AddWorkspaceAsync(ws);
+        await sut.SetActiveAsync(ws.Id);
+
+        await sut.RemoveWorkspaceAsync(ws.Id);
+
+        sut.Workspaces.Should().BeEmpty();
+        sut.Active.Should().BeNull();
+    }
+
+    [Fact]
+    public void ApiKey_ReturnsEmptyStringWhenNoActive()
+    {
+        // Not initialized — no active workspace
+        var sut = CreateSut(out _);
+
+        sut.ApiKey.Should().BeEmpty();
+    }
+
+    // ── Fake IJSRuntime backed by in-memory dictionary ──────────────────
+    // Argha - 2026-03-04 - #17 - Minimal stub; handles localStorage.getItem / setItem / removeItem only
+    private class FakeJSRuntime : IJSRuntime
+    {
+        private readonly Dictionary<string, string?> _storage = new();
+
+        public void SetItem(string key, string? value) => _storage[key] = value;
+        public string? GetItem(string key) => _storage.TryGetValue(key, out var v) ? v : null;
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        {
+            if (identifier == "localStorage.getItem" && args?.Length > 0)
+            {
+                _storage.TryGetValue((string)args[0]!, out var val);
+                TValue typed = (TValue)(object?)val!;
+                return ValueTask.FromResult(typed);
+            }
+            if (identifier == "localStorage.setItem" && args?.Length >= 2)
+                _storage[(string)args[0]!] = (string?)args[1];
+            if (identifier == "localStorage.removeItem" && args?.Length > 0)
+                _storage.Remove((string)args[0]!);
+            return ValueTask.FromResult<TValue>(default!);
+        }
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+            => InvokeAsync<TValue>(identifier, args);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `/workspaces` page: create (API key modal with copy + 10s timeout), switch, delete (3-second confirm), import-by-key
- Add navbar workspace chip (indigo dot + name, links to /workspaces)
- Scope Chat page conversation history per workspace (`rag_conversations_{workspaceId}`)
- Replace static `X-Api-Key` default header with `WorkspaceKeyHandler` DelegatingHandler — key injected dynamically from active workspace on every request
- Add `GET /api/workspaces/current` backend endpoint (used by import flow to resolve workspace ID + name from a raw API key)
- 8 new tests; 273 total (up from 265)

## Test plan

- [ ] `dotnet build RagApi.sln` — 0 errors
- [ ] `dotnet test tests/RagApi.Tests` — 273 pass
- [ ] Navigate to `/workspaces` — page loads with empty state
- [ ] Create "Test Corp" → modal shows API key → copy → Done → chip appears in navbar
- [ ] Upload a doc in Documents page → visible
- [ ] Create second workspace "Acme" → switch → Documents page empty (isolation confirmed)
- [ ] Switch back to Test Corp → doc reappears
- [ ] Chat: create conversation under Test Corp → switch to Acme → history empty → switch back → restored
- [ ] Import: paste Test Corp key with a display name → validates → adds to list → switches active
- [ ] Delete: click delete → Confirm? appears → 3s timeout clears it; click again fast → workspace removed

Refs #17