### PR TITLE
Add workspace onboarding gate + token guidance (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 [![Deploy](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml/badge.svg)](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml)
 ![.NET](https://img.shields.io/badge/.NET-8.0-512BD4?style=flat&logo=dotnet)
 ![C#](https://img.shields.io/badge/C%23-12-239120?style=flat&logo=csharp)
-![Tests](https://img.shields.io/badge/tests-273%20passing-brightgreen)
-![Phase](https://img.shields.io/badge/phase-10.1%20Workspace%20UI%20complete-brightgreen)
+![Tests](https://img.shields.io/badge/tests-275%20passing-brightgreen)
+![Phase](https://img.shields.io/badge/phase-10.2%20Onboarding%20gate%20complete-brightgreen)
 ![License](https://img.shields.io/badge/License-MIT-green.svg)
 
 ---
@@ -58,7 +58,10 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 
 ### Workspace UI ✅
 - **Workspaces page** — Create, switch, delete, and import workspaces from `/workspaces`
-- **Navbar chip** — Active workspace shown as indigo pill in the top navigation bar
+- **Navbar chip** — Active workspace shown as indigo pill in the top navigation bar; amber "Get Started →" badge shown to new users
+- **Onboarding guide** — 4-step setup instructions shown in the Workspaces empty state; step 2 highlighted in amber to warn about one-time API key
+- **Workspace gate** — Documents and Chat pages blocked behind a lock screen until at least one workspace is created
+- **No-documents banner** — Chat panel shows an info banner and disables the textarea when the active workspace has no documents uploaded
 - **Per-workspace chat history** — localStorage conversation list scoped by workspace ID; switches automatically on workspace change
 - **API key modal** — One-time display with clipboard copy; Done button re-enabled after 10 s if clipboard is blocked
 - **Import flow** — Paste an existing API key to link a workspace to this browser session (validates via `GET /api/documents`, resolves ID via `GET /api/workspaces/current`)
@@ -82,7 +85,7 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 - **GitHub Actions CI/CD** — Automated test, build, and deploy pipeline
 - **Azure deployment** — Container Apps (scales to zero) + Static Web Apps (free tier)
 - **Modern SaaS UI ✅** — Inter design system, indigo theme, drag-drop uploads, glassmorphism health dashboard, footer
-- **273 unit tests** — xUnit + Moq + FluentAssertions across all layers
+- **275 unit tests** — xUnit + Moq + FluentAssertions across all layers
 
 ---
 

--- a/src/RagApi.BlazorUI/Layout/NavMenu.razor
+++ b/src/RagApi.BlazorUI/Layout/NavMenu.razor
@@ -66,12 +66,24 @@
             </ul>
 
             @* Argha - 2026-03-04 - #17 - Active workspace chip shown on right end of navbar *@
+            @* Argha - 2026-03-07 - #20 - Amber badge shown when initialized but no workspace yet *@
             @if (WsState.Active != null)
             {
                 <div class="ms-auto me-3">
                     <a href="/workspaces" class="workspace-chip" style="text-decoration:none;">
                         <span class="ws-dot"></span>
                         @WsState.Active.Name
+                    </a>
+                </div>
+            }
+            else if (WsState.IsInitialized)
+            {
+                <div class="ms-auto me-3">
+                    <a href="/workspaces" class="nav-setup-prompt">
+                        Get Started
+                        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                            <line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/>
+                        </svg>
                     </a>
                 </div>
             }

--- a/src/RagApi.BlazorUI/Pages/Chat.razor
+++ b/src/RagApi.BlazorUI/Pages/Chat.razor
@@ -1,14 +1,41 @@
 @* Argha - 2026-03-03 - #13 - Chat page redesign: modern sidebar, indigo bubbles, improved input & sources *@
 @* Argha - 2026-03-04 - #17 - Scoped conversation list per workspace; reload on workspace switch *@
 @* Argha - 2026-02-21 - Original chat page: sidebar with conversation list + streaming message panel *@
+@* Argha - 2026-03-07 - #20 - Workspace gate + no-docs banner; textarea disabled when no documents *@
 @page "/"
 @inject ChatApiService ChatService
 @inject ConversationApiService ConversationService
 @inject LocalStorageService LocalStorage
 @inject WorkspaceStateService WsState
+@inject DocumentApiService DocService
 @implements IAsyncDisposable
 
 <PageTitle>Chat — RAG Chat</PageTitle>
+
+@* Argha - 2026-03-07 - #20 - Workspace gate: spinner while initializing, lock screen if no workspace *@
+@if (!_wsReady)
+{
+    <div style="display:flex;justify-content:center;padding:var(--space-12) 0;">
+        <div class="spinner-sm spinner-dark" style="width:24px;height:24px;border-width:3px;"></div>
+    </div>
+}
+else if (!WsState.HasWorkspaces)
+{
+    <div class="card-modern" style="max-width:480px;margin:var(--space-12) auto;">
+        <div class="empty-state" style="padding:var(--space-10) var(--space-8);">
+            <div class="empty-state-icon">
+                <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+                </svg>
+            </div>
+            <h3>No Workspace Selected</h3>
+            <p>Create a workspace first to start chatting with your documents.</p>
+            <a href="/workspaces" class="btn-primary-modern" style="margin-top:var(--space-4);">Set up a Workspace →</a>
+        </div>
+    </div>
+}
+else
+{
 
 <div class="chat-layout">
 
@@ -58,6 +85,16 @@
 
     @* ── Right panel: messages + input ── *@
     <div class="chat-panel">
+        @* Argha - 2026-03-07 - #20 - No-docs banner: shown when workspace has no documents yet *@
+        @if (_docCheckDone && !_hasDocuments)
+        {
+            <div class="alert-modern alert-info" style="margin:var(--space-3) var(--space-4) 0;">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="flex-shrink:0;">
+                    <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+                </svg>
+                No documents uploaded yet. <a href="/documents" style="color:inherit;font-weight:var(--weight-semibold);">Upload documents</a> before chatting.
+            </div>
+        }
         @if (_activeConvId == Guid.Empty)
         {
             <div class="chat-empty">
@@ -153,9 +190,9 @@
                               @onkeydown="HandleKeyDownAsync"
                               placeholder="Ask a question about your documents…"
                               rows="2"
-                              disabled="@_isStreaming"></textarea>
+                              disabled="@(_isStreaming || (_docCheckDone && !_hasDocuments))"></textarea>
                     <button class="send-btn" @onclick="SendMessageAsync"
-                            disabled="@(_isStreaming || string.IsNullOrWhiteSpace(_inputText))"
+                            disabled="@(_isStreaming || string.IsNullOrWhiteSpace(_inputText) || (_docCheckDone && !_hasDocuments))"
                             title="Send (Ctrl+Enter)">
                         @if (_isStreaming)
                         {
@@ -175,6 +212,8 @@
     </div>
 </div>
 
+} @* end else HasWorkspaces *@
+
 @code {
     // ── Conversation list (IDs persisted in localStorage per workspace) ──
     private List<StoredConversation> _conversations = new();
@@ -191,6 +230,13 @@
     private ElementReference _messagesContainer;
     private CancellationTokenSource? _streamCts;
 
+    // Argha - 2026-03-07 - #20 - Workspace gate state
+    private bool _wsReady;
+
+    // Argha - 2026-03-07 - #20 - Document check state; optimistic true to avoid flash-of-disabled on load
+    private bool _hasDocuments = true;
+    private bool _docCheckDone = false;
+
     protected override void OnInitialized()
     {
         // Argha - 2026-03-04 - #17 - Subscribe early so workspace switches reload conversation list
@@ -203,12 +249,17 @@
         {
             // Argha - 2026-03-04 - #17 - Ensure workspace state loaded before reading active workspace key
             await WsState.InitializeAsync();
-            await LoadConversationsAsync();
+            _wsReady = true;
+            if (WsState.HasWorkspaces)
+            {
+                await LoadConversationsAsync();
+                await CheckDocumentCountAsync();
+            }
             StateHasChanged();
         }
     }
 
-    // Argha - 2026-03-04 - #17 - Reload conversation list from new workspace key when active workspace changes
+    // Argha - 2026-03-07 - #20 - Reload conversation list from new workspace key when active workspace changes
     private void OnWorkspaceChanged()
     {
         _ = InvokeAsync(async () =>
@@ -216,9 +267,28 @@
             _conversations = new();
             _activeConvId = Guid.Empty;
             _messages = new();
-            await LoadConversationsAsync();
+            _docCheckDone = false;
+            _hasDocuments = true;
+            if (WsState.HasWorkspaces)
+            {
+                await LoadConversationsAsync();
+                await CheckDocumentCountAsync();
+            }
             StateHasChanged();
         });
+    }
+
+    // Argha - 2026-03-07 - #20 - Check if workspace has any documents; fail-open on API error
+    private async Task CheckDocumentCountAsync()
+    {
+        if (WsState.Active == null) return;
+        try
+        {
+            var docs = await DocService.GetDocumentsAsync();
+            _hasDocuments = docs.Count > 0;
+        }
+        catch { _hasDocuments = true; }  // fail-open: don't block chat on API error
+        finally { _docCheckDone = true; StateHasChanged(); }
     }
 
     // Argha - 2026-03-04 - #17 - Conversation list scoped per workspace: key = rag_conversations_{workspaceId}

--- a/src/RagApi.BlazorUI/Pages/Documents.razor
+++ b/src/RagApi.BlazorUI/Pages/Documents.razor
@@ -1,12 +1,41 @@
 @* Argha - 2026-03-03 - #14 - Documents page redesign: drag-drop zone, card grid, status dots, tag chips *@
 @* Argha - 2026-02-21 - Original documents page: upload card + table listing *@
+@* Argha - 2026-03-07 - #20 - Added workspace gate: page blocked until at least one workspace exists *@
 @page "/documents"
 @inject DocumentApiService DocumentService
+@inject WorkspaceStateService WsState
+@implements IDisposable
 
 <PageTitle>Documents — RAG Chat</PageTitle>
 
 <div class="page-body-scroll">
 <div style="max-width:1100px;margin:0 auto;padding:var(--space-6) var(--space-4);">
+
+@* Argha - 2026-03-07 - #20 - Workspace gate: spinner while loading, lock screen if no workspace *@
+@if (!_wsReady)
+{
+    <div style="display:flex;justify-content:center;padding:var(--space-12) 0;">
+        <div class="spinner-sm spinner-dark" style="width:24px;height:24px;border-width:3px;"></div>
+    </div>
+}
+else if (!WsState.HasWorkspaces)
+{
+    <div class="card-modern" style="max-width:480px;margin:var(--space-12) auto;">
+        <div class="empty-state" style="padding:var(--space-10) var(--space-8);">
+            <div class="empty-state-icon">
+                <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                    <rect x="3" y="11" width="18" height="11" rx="2"/>
+                    <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+                </svg>
+            </div>
+            <h3>No Workspace Selected</h3>
+            <p>You need a workspace before uploading documents. Each workspace has its own isolated knowledge base.</p>
+            <a href="/workspaces" class="btn-primary-modern" style="margin-top:var(--space-4);">Set up a Workspace →</a>
+        </div>
+    </div>
+}
+else
+{
 
     @* ── Page header ── *@
     <div class="section-header">
@@ -240,6 +269,8 @@
         </div>
     }
 
+} @* end else HasWorkspaces *@
+
 </div>
 </div>
 
@@ -259,11 +290,38 @@
 
     private HashSet<Guid> _deletingIds = new();
 
-    protected override async Task OnInitializedAsync()
+    // Argha - 2026-03-07 - #20 - true once workspace state is resolved from localStorage
+    private bool _wsReady;
+
+    // Argha - 2026-03-07 - #20 - JSInterop unavailable in OnInitializedAsync; gate and load in OnAfterRenderAsync
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        await Task.WhenAll(
-            LoadDocumentsAsync(null),
-            LoadSupportedTypesAsync());
+        if (firstRender)
+        {
+            WsState.OnChanged += OnWorkspaceChanged;
+            await WsState.InitializeAsync();
+            _wsReady = true;
+            if (WsState.HasWorkspaces)
+                await Task.WhenAll(LoadDocumentsAsync(null), LoadSupportedTypesAsync());
+            StateHasChanged();
+        }
+    }
+
+    // Argha - 2026-03-07 - #20 - Reload documents when the active workspace changes
+    private void OnWorkspaceChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            _documents = new();
+            if (WsState.HasWorkspaces)
+                await LoadDocumentsAsync(null);
+            StateHasChanged();
+        });
+    }
+
+    public void Dispose()
+    {
+        WsState.OnChanged -= OnWorkspaceChanged;
     }
 
     private async Task LoadDocumentsAsync(string? tag)

--- a/src/RagApi.BlazorUI/Pages/Workspaces.razor
+++ b/src/RagApi.BlazorUI/Pages/Workspaces.razor
@@ -63,18 +63,49 @@
     }
 
     @* ── Workspace cards ── *@
+    @* Argha - 2026-03-07 - #20 - Replaced empty state with 4-step onboarding guide *@
     @if (WsState.Workspaces.Count == 0)
     {
         <div class="card-modern" style="margin-bottom:var(--space-5);">
-            <div class="empty-state" style="padding:var(--space-10) var(--space-8);">
-                <div class="empty-state-icon">
-                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
-                        <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>
-                        <rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/>
-                    </svg>
+            <h3 style="font-size:var(--text-base);font-weight:var(--weight-semibold);color:var(--text-primary);margin:0 0 var(--space-1);">Get Started with RAG Chat</h3>
+            <p style="font-size:var(--text-sm);color:var(--text-muted);margin:0 0 var(--space-5);">Follow these steps to set up your workspace.</p>
+
+            <div class="onboarding-steps">
+                <div class="onboarding-step">
+                    <div class="onboarding-step-num">1</div>
+                    <div class="onboarding-step-body">
+                        <h4>Create a Workspace</h4>
+                        <p>Click "New Workspace" above, give it a name, and click Create.</p>
+                    </div>
                 </div>
-                <h3>No workspaces yet</h3>
-                <p>Create your first workspace to start isolating data per team or client.</p>
+                <div class="onboarding-step">
+                    <div class="onboarding-step-num step-warn">2</div>
+                    <div class="onboarding-step-body">
+                        <h4>Save Your API Key</h4>
+                        <p>Your key is shown <strong>once</strong> and cannot be retrieved again. Store it in a password manager or secure note.</p>
+                    </div>
+                </div>
+                <div class="onboarding-step">
+                    <div class="onboarding-step-num">3</div>
+                    <div class="onboarding-step-body">
+                        <h4>Upload Documents</h4>
+                        <p>Go to Documents and upload PDF, DOCX, TXT, or MD files.</p>
+                    </div>
+                </div>
+                <div class="onboarding-step">
+                    <div class="onboarding-step-num">4</div>
+                    <div class="onboarding-step-body">
+                        <h4>Start Chatting</h4>
+                        <p>Go to Chat and ask questions about your documents.</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="alert-modern alert-info" style="margin-top:var(--space-5);">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="flex-shrink:0;">
+                    <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+                </svg>
+                <span><strong>Returning on another device or browser?</strong> Use the Import section below with your saved key to reconnect to your data.</span>
             </div>
         </div>
     }

--- a/src/RagApi.BlazorUI/Services/WorkspaceStateService.cs
+++ b/src/RagApi.BlazorUI/Services/WorkspaceStateService.cs
@@ -25,6 +25,12 @@ public class WorkspaceStateService
     // Argha - 2026-03-04 - #17 - Consumed by WorkspaceKeyHandler on every outgoing request
     public string ApiKey => Active?.ApiKey ?? string.Empty;
 
+    // Argha - 2026-03-07 - #20 - true once InitializeAsync has finished reading localStorage
+    public bool IsInitialized => _initialized;
+
+    // Argha - 2026-03-07 - #20 - true if at least one workspace exists in this browser session
+    public bool HasWorkspaces => _workspaces.Count > 0;
+
     public event Action? OnChanged;
 
     public WorkspaceStateService(IJSRuntime js, IConfiguration config)
@@ -47,20 +53,20 @@ public class WorkspaceStateService
         if (Guid.TryParse(activeIdStr, out var id))
             _activeId = id;
 
-        // Argha - 2026-03-04 - #17 - Backward compat: seed default workspace from appsettings ApiKey on first launch
-        if (_workspaces.Count == 0 && !string.IsNullOrEmpty(_fallbackApiKey))
-        {
-            var defaultWs = new StoredWorkspace
-            {
-                Id = Guid.NewGuid(),
-                Name = "Default",
-                ApiKey = _fallbackApiKey,
-                CreatedAt = DateTime.UtcNow
-            };
-            _workspaces.Add(defaultWs);
-            _activeId = defaultWs.Id;
-            await PersistAsync();
-        }
+        // Argha - 2026-03-07 - #20 - removed: silent default-workspace seed; users must now explicitly create a workspace
+        // if (_workspaces.Count == 0 && !string.IsNullOrEmpty(_fallbackApiKey))
+        // {
+        //     var defaultWs = new StoredWorkspace
+        //     {
+        //         Id = Guid.NewGuid(),
+        //         Name = "Default",
+        //         ApiKey = _fallbackApiKey,
+        //         CreatedAt = DateTime.UtcNow
+        //     };
+        //     _workspaces.Add(defaultWs);
+        //     _activeId = defaultWs.Id;
+        //     await PersistAsync();
+        // }
     }
 
     public async Task AddWorkspaceAsync(StoredWorkspace ws)

--- a/src/RagApi.BlazorUI/wwwroot/css/components.css
+++ b/src/RagApi.BlazorUI/wwwroot/css/components.css
@@ -446,3 +446,29 @@
   margin: 0;
   margin-top: 2px;
 }
+
+/* Argha - 2026-03-07 - #20 - Onboarding steps (Workspaces page empty state) */
+.onboarding-steps { display: flex; flex-direction: column; gap: var(--space-4); margin: var(--space-5) 0; }
+.onboarding-step { display: flex; gap: var(--space-4); align-items: flex-start; }
+.onboarding-step-num {
+  flex-shrink: 0; width: 28px; height: 28px; border-radius: 50%;
+  background: var(--primary-light); border: 1.5px solid var(--primary-mid);
+  color: var(--primary-hover); font-size: var(--text-xs); font-weight: var(--weight-semibold);
+  display: flex; align-items: center; justify-content: center;
+}
+.onboarding-step-num.step-warn {
+  background: var(--warning-light); border-color: #fcd34d; color: var(--warning-text);
+}
+.onboarding-step-body h4 { font-size: var(--text-sm); font-weight: var(--weight-semibold); color: var(--text-primary); margin: 0 0 2px; }
+.onboarding-step-body p  { font-size: var(--text-xs); color: var(--text-muted); margin: 0; line-height: 1.5; }
+
+/* Argha - 2026-03-07 - #20 - Nav setup prompt (amber badge when no workspace) */
+.nav-setup-prompt {
+  display: inline-flex; align-items: center; gap: var(--space-1);
+  padding: 4px 10px; background: var(--warning-light);
+  border: 1px solid #fcd34d; border-radius: var(--radius-full);
+  font-size: var(--text-xs); font-weight: var(--weight-semibold);
+  color: var(--warning-text); white-space: nowrap;
+  transition: background var(--transition-fast); text-decoration: none;
+}
+.nav-setup-prompt:hover { background: #fef3c7; }

--- a/tests/RagApi.Tests/Unit/Services/WorkspaceStateServiceTests.cs
+++ b/tests/RagApi.Tests/Unit/Services/WorkspaceStateServiceTests.cs
@@ -96,6 +96,34 @@ public class WorkspaceStateServiceTests
         sut.ApiKey.Should().BeEmpty();
     }
 
+    // Argha - 2026-03-07 - #20 - Verify seed block removal: fallbackApiKey no longer creates default workspace
+    [Fact]
+    public async Task InitializeAsync_WithNoStoredData_DoesNotSeedDefaultWorkspace()
+    {
+        var sut = CreateSut(out _, fallbackApiKey: "global-key");
+
+        await sut.InitializeAsync();
+
+        sut.Workspaces.Should().BeEmpty();
+        sut.Active.Should().BeNull();
+        sut.HasWorkspaces.Should().BeFalse();
+        sut.IsInitialized.Should().BeTrue();
+    }
+
+    // Argha - 2026-03-07 - #20 - HasWorkspaces reflects actual workspace list state
+    [Fact]
+    public async Task HasWorkspaces_ReturnsFalseInitially_TrueAfterAdd()
+    {
+        var sut = CreateSut(out _);
+        await sut.InitializeAsync();
+        sut.HasWorkspaces.Should().BeFalse();
+
+        var ws = new StoredWorkspace { Id = Guid.NewGuid(), Name = "X", ApiKey = "k", CreatedAt = DateTime.UtcNow };
+        await sut.AddWorkspaceAsync(ws);
+
+        sut.HasWorkspaces.Should().BeTrue();
+    }
+
     // ── Fake IJSRuntime backed by in-memory dictionary ──────────────────
     // Argha - 2026-03-04 - #17 - Minimal stub; handles localStorage.getItem / setItem / removeItem only
     private class FakeJSRuntime : IJSRuntime


### PR DESCRIPTION
## Summary

- Removes the silent default-workspace seed in `WorkspaceStateService` — users must now explicitly create a workspace before using the app
- Gates Documents and Chat pages behind a lock screen until a workspace exists in localStorage; spinner shown during initialization
- Adds an amber "Get Started →" badge in the navbar for users with no workspace; replaced by the green chip once one is active
- Adds a 4-step onboarding guide to the Workspaces page empty state, with step 2 amber-highlighted to warn about the one-time API key
- Adds a no-documents info banner to the Chat panel and disables the textarea/send button when the active workspace has no documents uploaded (fail-open on API error)
- +2 tests: seed-removal verification + `HasWorkspaces` state transitions (273 → 275 total)

## Files changed

| File | Change |
|---|---|
| `WorkspaceStateService.cs` | Seed block commented out; `IsInitialized` + `HasWorkspaces` added |
| `Documents.razor` | Workspace gate; loads moved to `OnAfterRenderAsync`; `OnChanged` subscription |
| `Chat.razor` | Workspace gate; no-docs banner; textarea disabled when no docs |
| `Workspaces.razor` | 4-step onboarding guide replaces empty state |
| `NavMenu.razor` | Amber "Get Started →" badge when initialized but no workspace |
| `components.css` | `.onboarding-steps`, `.step-warn`, `.nav-setup-prompt` styles |
| `WorkspaceStateServiceTests.cs` | 2 new tests |
| `README.md` | Updated feature list and test count badge |

## Test plan

- [x] `dotnet test` → 275 passing, 0 failed
- [x] Clear localStorage (`localStorage.clear()`) → Chat shows lock screen, Documents shows lock screen, navbar shows amber badge
- [x] Visit `/workspaces` with no workspace → 4-step guide visible above create form
- [x] Create a workspace and dismiss modal → lock screens gone, green chip in navbar
- [x] Navigate to Chat with no documents → info banner visible, textarea disabled
- [x] Upload a document → banner disappears, textarea re-enables
- [x] Reload with workspaces in localStorage → no gate on any page

Closes #20