### PR TITLE
Add OpenAI and AzureOpenAI health checks (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 [![Deploy](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml/badge.svg)](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml)
 ![.NET](https://img.shields.io/badge/.NET-8.0-512BD4?style=flat&logo=dotnet)
 ![C#](https://img.shields.io/badge/C%23-12-239120?style=flat&logo=csharp)
-![Tests](https://img.shields.io/badge/tests-275%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-279%20passing-brightgreen)
 ![Phase](https://img.shields.io/badge/phase-10.2%20Onboarding%20gate%20complete-brightgreen)
 ![License](https://img.shields.io/badge/License-MIT-green.svg)
 
@@ -85,7 +85,7 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 - **GitHub Actions CI/CD** — Automated test, build, and deploy pipeline
 - **Azure deployment** — Container Apps (scales to zero) + Static Web Apps (free tier)
 - **Modern SaaS UI ✅** — Inter design system, indigo theme, drag-drop uploads, glassmorphism health dashboard, footer
-- **275 unit tests** — xUnit + Moq + FluentAssertions across all layers
+- **279 unit tests** — xUnit + Moq + FluentAssertions across all layers
 
 ---
 

--- a/src/RagApi.Infrastructure/DependencyInjection.cs
+++ b/src/RagApi.Infrastructure/DependencyInjection.cs
@@ -117,19 +117,13 @@ public static class DependencyInjection
             healthChecks.AddCheck<QdrantHealthCheck>("qdrant", tags: ["dependency"]);
         }
 
+        // Argha - 2026-03-07 - #22 - Register AI provider health check based on active provider
         if (aiConfig.Provider.Equals("AzureOpenAI", StringComparison.OrdinalIgnoreCase))
-        {
-            // Azure OpenAI health check can be added in a future phase
-        }
-        // Argha - 2026-03-01 - OpenAI is a managed external service — no local health check needed
+            healthChecks.AddCheck<AzureOpenAiHealthCheck>("azure-openai", tags: ["dependency"]);
         else if (aiConfig.Provider.Equals("OpenAI", StringComparison.OrdinalIgnoreCase))
-        {
-            // No Ollama health check for OpenAI provider
-        }
+            healthChecks.AddCheck<OpenAiHealthCheck>("openai", tags: ["dependency"]);
         else
-        {
             healthChecks.AddCheck<OllamaHealthCheck>("ollama", tags: ["dependency"]);
-        }
 
         return services;
     }

--- a/src/RagApi.Infrastructure/HealthChecks/AzureOpenAiHealthCheck.cs
+++ b/src/RagApi.Infrastructure/HealthChecks/AzureOpenAiHealthCheck.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RagApi.Infrastructure.HealthChecks;
+
+// Argha - 2026-03-07 - #22 - Health check for Azure OpenAI service connectivity
+public class AzureOpenAiHealthCheck : IHealthCheck
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly AzureOpenAiSettings _settings;
+    private readonly ILogger<AzureOpenAiHealthCheck> _logger;
+
+    public AzureOpenAiHealthCheck(
+        IHttpClientFactory httpClientFactory,
+        IOptions<AiConfiguration> config,
+        ILogger<AzureOpenAiHealthCheck> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _settings = config.Value.AzureOpenAI;
+        _logger = logger;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var client = _httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(5);
+            client.DefaultRequestHeaders.Add("api-key", _settings.ApiKey);
+
+            var response = await client.GetAsync(
+                $"{_settings.Endpoint}/openai/models?api-version=2024-02-01", cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var data = new Dictionary<string, object>
+            {
+                ["provider"] = "AzureOpenAI",
+                ["endpoint"] = _settings.Endpoint,
+                ["chatDeployment"] = _settings.ChatDeployment,
+                ["embeddingDeployment"] = _settings.EmbeddingDeployment
+            };
+            return HealthCheckResult.Healthy("Azure OpenAI reachable", data);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Azure OpenAI health check failed");
+            return HealthCheckResult.Unhealthy("Azure OpenAI unreachable", ex);
+        }
+    }
+}

--- a/src/RagApi.Infrastructure/HealthChecks/OpenAiHealthCheck.cs
+++ b/src/RagApi.Infrastructure/HealthChecks/OpenAiHealthCheck.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace RagApi.Infrastructure.HealthChecks;
+
+// Argha - 2026-03-07 - #22 - Health check for OpenAI API connectivity
+public class OpenAiHealthCheck : IHealthCheck
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly OpenAiSettings _settings;
+    private readonly ILogger<OpenAiHealthCheck> _logger;
+
+    public OpenAiHealthCheck(
+        IHttpClientFactory httpClientFactory,
+        IOptions<AiConfiguration> config,
+        ILogger<OpenAiHealthCheck> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _settings = config.Value.OpenAi;
+        _logger = logger;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var client = _httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(5);
+            client.DefaultRequestHeaders.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _settings.ApiKey);
+
+            var response = await client.GetAsync(
+                $"{_settings.BaseUrl}/models", cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var data = new Dictionary<string, object>
+            {
+                ["provider"] = "OpenAI",
+                ["chatModel"] = _settings.ChatModel,
+                ["embeddingModel"] = _settings.EmbeddingModel
+            };
+            return HealthCheckResult.Healthy("OpenAI reachable", data);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "OpenAI health check failed");
+            return HealthCheckResult.Unhealthy("OpenAI unreachable", ex);
+        }
+    }
+}

--- a/tests/RagApi.Tests/Unit/Infrastructure/HealthCheckTests.cs
+++ b/tests/RagApi.Tests/Unit/Infrastructure/HealthCheckTests.cs
@@ -79,6 +79,145 @@ public class HealthCheckTests
         result.Description.Should().Contain("Ollama unreachable");
     }
 
+    // Argha - 2026-03-07 - #22 - OpenAI and Azure OpenAI health check tests
+    [Fact]
+    public async Task OpenAiHealthCheck_Success_ReturnsHealthy()
+    {
+        // Arrange
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var httpClient = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var config = Options.Create(new AiConfiguration
+        {
+            OpenAi = new OpenAiSettings { ApiKey = "sk-test", BaseUrl = "https://api.openai.com/v1" }
+        });
+
+        var healthCheck = new OpenAiHealthCheck(
+            factoryMock.Object, config, Mock.Of<ILogger<OpenAiHealthCheck>>());
+
+        // Act
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        // Assert
+        result.Status.Should().Be(HealthStatus.Healthy);
+        result.Description.Should().Contain("OpenAI reachable");
+    }
+
+    [Fact]
+    public async Task OpenAiHealthCheck_Failure_ReturnsUnhealthy()
+    {
+        // Arrange
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Connection refused"));
+
+        var httpClient = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var config = Options.Create(new AiConfiguration
+        {
+            OpenAi = new OpenAiSettings { ApiKey = "sk-test", BaseUrl = "https://api.openai.com/v1" }
+        });
+
+        var healthCheck = new OpenAiHealthCheck(
+            factoryMock.Object, config, Mock.Of<ILogger<OpenAiHealthCheck>>());
+
+        // Act
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        // Assert
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Description.Should().Contain("OpenAI unreachable");
+    }
+
+    [Fact]
+    public async Task AzureOpenAiHealthCheck_Success_ReturnsHealthy()
+    {
+        // Arrange
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var httpClient = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var config = Options.Create(new AiConfiguration
+        {
+            AzureOpenAI = new AzureOpenAiSettings
+            {
+                Endpoint = "https://my-resource.openai.azure.com",
+                ApiKey = "test-key",
+                ChatDeployment = "gpt-4",
+                EmbeddingDeployment = "text-embedding-ada-002"
+            }
+        });
+
+        var healthCheck = new AzureOpenAiHealthCheck(
+            factoryMock.Object, config, Mock.Of<ILogger<AzureOpenAiHealthCheck>>());
+
+        // Act
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        // Assert
+        result.Status.Should().Be(HealthStatus.Healthy);
+        result.Description.Should().Contain("Azure OpenAI reachable");
+    }
+
+    [Fact]
+    public async Task AzureOpenAiHealthCheck_Failure_ReturnsUnhealthy()
+    {
+        // Arrange
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Connection refused"));
+
+        var httpClient = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var config = Options.Create(new AiConfiguration
+        {
+            AzureOpenAI = new AzureOpenAiSettings
+            {
+                Endpoint = "https://my-resource.openai.azure.com",
+                ApiKey = "test-key"
+            }
+        });
+
+        var healthCheck = new AzureOpenAiHealthCheck(
+            factoryMock.Object, config, Mock.Of<ILogger<AzureOpenAiHealthCheck>>());
+
+        // Act
+        var result = await healthCheck.CheckHealthAsync(new HealthCheckContext());
+
+        // Assert
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Description.Should().Contain("Azure OpenAI unreachable");
+    }
+
     // Argha - 2026-03-02 - #6 - disabled: SqliteHealthCheck replaced by PostgresHealthCheck (Phase 8)
     // Tests for PostgresHealthCheck are in Phase8Tests.cs
     // [Fact]


### PR DESCRIPTION
## Summary

- Add `OpenAiHealthCheck`: `GET {BaseUrl}/models` with `Authorization: Bearer` header, 5-second timeout
- Add `AzureOpenAiHealthCheck`: `GET {Endpoint}/openai/models?api-version=2024-02-01` with `api-key` header, 5-second timeout
- Register both checks conditionally in `DependencyInjection.cs` — same pattern as `OllamaHealthCheck`
- Health UI renders new cards automatically (no frontend changes needed)

## Test plan

- [x] `dotnet build RagApi.sln` — 0 errors
- [x] `dotnet test tests/RagApi.Tests` — 279 pass (275 → 279, +4 new health check tests)
- [x] Set `AI:Provider=OpenAI` with valid key → `"openai"` card shows `Healthy`
- [x] Set invalid API key → `"openai"` card shows `Unhealthy`

Closes #22