### PR TITLE
Fix workspace init race causing No Workspace Selected on load

### DIFF
--- a/src/RagApi.BlazorUI/Pages/Chat.razor
+++ b/src/RagApi.BlazorUI/Pages/Chat.razor
@@ -301,7 +301,12 @@ else
                 .Select(s => new StoredConversation { Id = s.SessionId, Title = s.Title, CreatedAt = s.CreatedAt })
                 .ToList();
         }
-        catch { _conversations = new(); }
+        catch (Exception ex)
+        {
+            // Argha - 2026-03-16 - #25 - Surface load error so it is visible; previously swallowed silently
+            _errorMessage = $"Could not load conversations: {ex.Message}";
+            _conversations = new();
+        }
 
         if (_conversations.Count > 0)
             await SelectConversationAsync(_conversations[0].Id);

--- a/src/RagApi.BlazorUI/Services/WorkspaceStateService.cs
+++ b/src/RagApi.BlazorUI/Services/WorkspaceStateService.cs
@@ -53,6 +53,10 @@ public class WorkspaceStateService
         if (Guid.TryParse(activeIdStr, out var id))
             _activeId = id;
 
+        // Argha - 2026-03-16 - #25 - Notify subscribers after localStorage reads complete so Chat.razor
+        // re-evaluates HasWorkspaces even when it called InitializeAsync during NavMenu's in-flight await
+        OnChanged?.Invoke();
+
         // Argha - 2026-03-07 - #20 - removed: silent default-workspace seed; users must now explicitly create a workspace
         // if (_workspaces.Count == 0 && !string.IsNullOrEmpty(_fallbackApiKey))
         // {


### PR DESCRIPTION
## Summary
- `WorkspaceStateService.InitializeAsync()` sets `_initialized = true` before `await`ing localStorage — when `Chat.razor`'s `OnAfterRenderAsync` fires during NavMenu's in-flight reads, it gets an early return with empty data and renders "No Workspace Selected" permanently
- Fix: fire `OnChanged?.Invoke()` after both localStorage reads complete so Chat re-evaluates `HasWorkspaces`
- Also surfaces `LoadConversationsAsync` errors instead of swallowing them silently

## Test plan
- [ ] Open app with a configured workspace — should show chat UI immediately, not "No Workspace Selected"
- [ ] Previous conversations should load without navigating away first
- [ ] If conversation API fails, error message is visible in the UI

Fixes #25