### PR TITLE
Fix deploy: always force new Container App revision per push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,17 +59,15 @@ jobs:
             --resource-group rg-rag-demo \
             --secrets "pg-connection-string=${{ secrets.POSTGRES_CONNECTION_STRING }}"
 
-      # Argha - 2026-03-02 - #8 - Wire secret to env var; safe to re-run on every deploy
-      - name: Wire PostgreSQL secret as environment variable
+      # Argha - 2026-03-16 - #27 - Single update: sets image + env var + revision-suffix in one call.
+      # Combining into one step avoids the previous bug where --set-env-vars created a revision with
+      # the OLD :latest image, leaving the deploy action with nothing new to do.
+      # --revision-suffix sha-<short-sha> guarantees a new revision on every push.
+      - name: Deploy to Azure Container Apps
         run: |
           az containerapp update \
             --name rag-api \
             --resource-group rg-rag-demo \
-            --set-env-vars "ConnectionStrings__DefaultConnection=secretref:pg-connection-string"
-
-      - name: Deploy to Azure Container Apps
-        uses: azure/container-apps-deploy-action@v2
-        with:
-          resourceGroup: rg-rag-demo
-          containerAppName: rag-api
-          imageToDeploy: ghcr.io/argha713/dotnet-rag-api:latest
+            --image ghcr.io/argha713/dotnet-rag-api:latest \
+            --set-env-vars "ConnectionStrings__DefaultConnection=secretref:pg-connection-string" \
+            --revision-suffix sha-$(echo "${{ github.sha }}" | cut -c1-7)


### PR DESCRIPTION
## Summary
- `az containerapp update --set-env-vars` was creating a revision with the **old** `:latest` image before the deploy action ran, leaving the action with nothing to do
- PRs #24 and #26 appeared deployed (green CI) but the Container App was still running `rag-api--openai-healthcheck` from PR #23 — missing `GET /api/conversations` entirely (405 in production)
- Fix: single `az containerapp update` with `--image`, `--set-env-vars`, and `--revision-suffix sha-<sha>` ensures a new revision on every push

## Test plan
- [ ] Merge and verify CI creates a revision named `rag-api--sha-<commit-sha>`
- [ ] Verify `GET /api/conversations` returns 200 (not 405)
- [ ] Verify old chat history loads in the UI

Fixes #27