### PR TITLE
Add IVisionService + IImageStore interfaces (Application layer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ secrets.json
 .claude/
 CLAUDE.md
 
+# Superpowers plans (local dev tooling)
+docs/
+
 # Test files
 test-sample.txt
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 [![Deploy](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml/badge.svg)](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml)
 ![.NET](https://img.shields.io/badge/.NET-8.0-512BD4?style=flat&logo=dotnet)
 ![C#](https://img.shields.io/badge/C%23-12-239120?style=flat&logo=csharp)
-![Tests](https://img.shields.io/badge/tests-283%20passing-brightgreen)
-![Phase](https://img.shields.io/badge/phase-10.3%20Server--side%20conversation%20list-brightgreen)
+![Tests](https://img.shields.io/badge/tests-287%20passing-brightgreen)
+![Phase](https://img.shields.io/badge/phase-14.1%20IVisionService%20%2B%20IImageStore-brightgreen)
 ![License](https://img.shields.io/badge/License-MIT-green.svg)
 
 ---
@@ -86,7 +86,7 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 - **GitHub Actions CI/CD** — Automated test, build, and deploy pipeline
 - **Azure deployment** — Container Apps (scales to zero) + Static Web Apps (free tier)
 - **Modern SaaS UI ✅** — Inter design system, indigo theme, drag-drop uploads, glassmorphism health dashboard, footer
-- **283 unit tests** — xUnit + Moq + FluentAssertions across all layers
+- **287 unit tests** — xUnit + Moq + FluentAssertions across all layers
 
 ---
 

--- a/src/RagApi.Application/Interfaces/IImageStore.cs
+++ b/src/RagApi.Application/Interfaces/IImageStore.cs
@@ -1,0 +1,19 @@
+using RagApi.Domain.Entities;
+
+namespace RagApi.Application.Interfaces;
+
+// Argha - 2026-03-16 - #31 - Contract for persisting and retrieving DocumentImage records.
+// PostgreSQL implementation in Infrastructure (#33).
+public interface IImageStore
+{
+    // Argha - 2026-03-16 - #31 - Persists image to the store; returns the image's Id
+    // (same as image.Id — callers can use the return value without keeping entity reference)
+    Task<Guid> SaveAsync(DocumentImage image, CancellationToken ct = default);
+
+    // Argha - 2026-03-16 - #31 - Returns null when no image with the given id exists
+    Task<DocumentImage?> GetAsync(Guid id, CancellationToken ct = default);
+
+    // Argha - 2026-03-16 - #31 - Cascade delete: removes all images for a document.
+    // Called by DocumentService (#36) during document deletion.
+    Task DeleteByDocumentAsync(Guid documentId, CancellationToken ct = default);
+}

--- a/src/RagApi.Application/Interfaces/IVisionService.cs
+++ b/src/RagApi.Application/Interfaces/IVisionService.cs
@@ -1,0 +1,18 @@
+namespace RagApi.Application.Interfaces;
+
+// Argha - 2026-03-16 - #31 - Contract for AI vision description of images extracted from documents.
+// GPT-4o implementation in Infrastructure (#32); false IsEnabled guards callers when no vision model configured.
+public interface IVisionService
+{
+    // Argha - 2026-03-16 - #31 - imageBytes: raw image data; mimeType: e.g. "image/png";
+    // context: optional hint to the model (e.g. document title or surrounding text)
+    Task<string> DescribeImageAsync(
+        byte[] imageBytes,
+        string mimeType,
+        string? context = null,
+        CancellationToken ct = default);
+
+    // Argha - 2026-03-16 - #31 - False when no vision-capable model is configured;
+    // DocumentService (#36) skips vision processing entirely when false
+    bool IsEnabled { get; }
+}

--- a/tests/RagApi.Tests/Unit/Application/VisionInterfaceTests.cs
+++ b/tests/RagApi.Tests/Unit/Application/VisionInterfaceTests.cs
@@ -1,0 +1,73 @@
+// Argha - 2026-03-16 - #31 - Contract tests: verify IVisionService and IImageStore
+// are Moq-mockable and expose the correct method signatures
+using FluentAssertions;
+using Moq;
+using RagApi.Application.Interfaces;
+using RagApi.Domain.Entities;
+
+namespace RagApi.Tests.Unit.Application;
+
+public class VisionInterfaceTests
+{
+    // Argha - 2026-03-16 - #31 - IVisionService: mock can describe an image and return a string
+    [Fact]
+    public async Task IVisionService_DescribeImageAsync_ReturnsDescription()
+    {
+        var mock = new Mock<IVisionService>();
+        mock.Setup(s => s.DescribeImageAsync(
+                It.IsAny<byte[]>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync("A diagram showing installation steps.");
+
+        var result = await mock.Object.DescribeImageAsync(
+            new byte[] { 0xFF, 0xD8 }, "image/jpeg", "installation manual");
+
+        result.Should().Be("A diagram showing installation steps.");
+    }
+
+    // Argha - 2026-03-16 - #31 - IVisionService: IsEnabled property is mockable
+    [Fact]
+    public void IVisionService_IsEnabled_ReturnsFalseWhenNotConfigured()
+    {
+        var mock = new Mock<IVisionService>();
+        mock.Setup(s => s.IsEnabled).Returns(false);
+
+        mock.Object.IsEnabled.Should().BeFalse();
+    }
+
+    // Argha - 2026-03-16 - #31 - IImageStore: SaveAsync returns the image Id
+    [Fact]
+    public async Task IImageStore_SaveAsync_ReturnsImageId()
+    {
+        var image = new DocumentImage
+        {
+            DocumentId = Guid.NewGuid(),
+            WorkspaceId = Guid.NewGuid(),
+            ContentType = "image/png",
+            Data = new byte[] { 1, 2, 3 }
+        };
+
+        var mock = new Mock<IImageStore>();
+        mock.Setup(s => s.SaveAsync(image, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(image.Id);
+
+        var returnedId = await mock.Object.SaveAsync(image);
+
+        returnedId.Should().Be(image.Id);
+    }
+
+    // Argha - 2026-03-16 - #31 - IImageStore: GetAsync returns null for unknown id
+    [Fact]
+    public async Task IImageStore_GetAsync_ReturnsNullForUnknownId()
+    {
+        var mock = new Mock<IImageStore>();
+        mock.Setup(s => s.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DocumentImage?)null);
+
+        var result = await mock.Object.GetAsync(Guid.NewGuid());
+
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `IVisionService` — contract for AI vision description of images (`DescribeImageAsync` + `IsEnabled` guard)
- Adds `IImageStore` — contract for `DocumentImage` persistence (`SaveAsync` / `GetAsync` / `DeleteByDocumentAsync`)
- Adds 4 interface contract tests in `Unit/Application/` (287 total, 0 regressions)
- Ignores `docs/` folder in `.gitignore`

Part of Phase 14: Multimodal RAG — downstream issues (#32, #33, #36) depend on these contracts.

## Test plan

- [x] `dotnet build RagApi.sln` — 0 errors
- [x] `VisionInterfaceTests` — 4/4 pass
- [x] Full suite — 287 passed, 0 failed

Closes #31