### PR TITLE
Add ExtractImagesAsync — PDF image extraction (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 [![Deploy](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml/badge.svg)](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml)
 ![.NET](https://img.shields.io/badge/.NET-8.0-512BD4?style=flat&logo=dotnet)
 ![C#](https://img.shields.io/badge/C%23-12-239120?style=flat&logo=csharp)
-![Tests](https://img.shields.io/badge/tests-287%20passing-brightgreen)
-![Phase](https://img.shields.io/badge/phase-14.1%20IVisionService%20%2B%20IImageStore-brightgreen)
+![Tests](https://img.shields.io/badge/tests-304%20passing-brightgreen)
+![Phase](https://img.shields.io/badge/phase-14.4%20PDF%20image%20extraction-brightgreen)
 ![License](https://img.shields.io/badge/License-MIT-green.svg)
 
 ---
@@ -86,7 +86,7 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 - **GitHub Actions CI/CD** — Automated test, build, and deploy pipeline
 - **Azure deployment** — Container Apps (scales to zero) + Static Web Apps (free tier)
 - **Modern SaaS UI ✅** — Inter design system, indigo theme, drag-drop uploads, glassmorphism health dashboard, footer
-- **287 unit tests** — xUnit + Moq + FluentAssertions across all layers
+- **304 unit tests** — xUnit + Moq + FluentAssertions across all layers
 
 ---
 
@@ -300,7 +300,7 @@ Cors__AllowedOrigins__0=https://your-frontend.azurestaticapps.net
 | **Frontend** | Blazor WebAssembly (.NET 8) — Inter design system, indigo theme |
 | **Hosting** | Azure Container Apps + Azure Static Web Apps |
 | **CI/CD** | GitHub Actions → GHCR → Azure |
-| **Testing** | xUnit, Moq, FluentAssertions (273 tests) |
+| **Testing** | xUnit, Moq, FluentAssertions (304 tests) |
 | **API Docs** | Swagger / OpenAPI |
 
 ---
@@ -316,7 +316,7 @@ dotnet-rag-api/
 │   ├── RagApi.Domain/           # Core entities
 │   └── RagApi.Infrastructure/   # Qdrant, OpenAI, Azure, EF Core
 ├── tests/
-│   └── RagApi.Tests/            # 273 unit tests
+│   └── RagApi.Tests/            # 304 unit tests
 ├── .github/workflows/           # CI, Deploy API, Deploy UI
 ├── docker-compose.yml           # Local Qdrant + Ollama + PostgreSQL
 ├── Dockerfile                   # Production container image

--- a/src/RagApi.Application/Interfaces/IDocumentProcessor.cs
+++ b/src/RagApi.Application/Interfaces/IDocumentProcessor.cs
@@ -26,7 +26,21 @@ public interface IDocumentProcessor
     /// Get list of supported content types
     /// </summary>
     IReadOnlyList<string> SupportedContentTypes { get; }
+
+    /// <summary>
+    /// Extract images from a document. Currently supports PDF only; returns empty list for all other content types.
+    /// </summary>
+    Task<List<ExtractedImage>> ExtractImagesAsync(Stream fileStream, string contentType, CancellationToken ct = default);
 }
+
+// Argha - 2026-03-16 - #34 - Image extracted from a PDF page; used by the multimodal ingestion pipeline
+public record ExtractedImage(
+    int PageNumber,
+    int ImageIndex,
+    byte[] Bytes,
+    string MimeType,
+    int WidthPx,
+    int HeightPx);
 
 // Argha - 2026-02-20 - Chunking strategy selection
 public enum ChunkingStrategy

--- a/src/RagApi.Infrastructure/DocumentProcessing/DocumentProcessor.cs
+++ b/src/RagApi.Infrastructure/DocumentProcessing/DocumentProcessor.cs
@@ -2,6 +2,7 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using UglyToad.PdfPig;
 using UglyToad.PdfPig.Content;
+using UglyToad.PdfPig.Tokens;
 using RagApi.Application.Interfaces;
 using RagApi.Domain.Entities;
 using Microsoft.Extensions.Logging;
@@ -295,5 +296,89 @@ public class DocumentProcessor : IDocumentProcessor
     {
         using var reader = new StreamReader(fileStream);
         return await reader.ReadToEndAsync(cancellationToken);
+    }
+
+    // Argha - 2026-03-16 - #34 - Extract images from PDF pages; non-PDF types return empty (DOCX handled in #35)
+    public Task<List<ExtractedImage>> ExtractImagesAsync(Stream fileStream, string contentType, CancellationToken ct = default)
+    {
+        if (!contentType.Equals("application/pdf", StringComparison.OrdinalIgnoreCase))
+            return Task.FromResult(new List<ExtractedImage>());
+
+        var results = new List<ExtractedImage>();
+
+        using var document = PdfDocument.Open(fileStream);
+        var pageNumber = 0;
+
+        foreach (var page in document.GetPages())
+        {
+            pageNumber++;
+            var imageIndex = 0;
+
+            foreach (var image in page.GetImages())
+            {
+                // Argha - 2026-03-16 - #34 - Skip decorative/icon images below minimum dimension threshold
+                if (image.WidthInSamples < 100 || image.HeightInSamples < 100)
+                    continue;
+
+                // Argha - 2026-03-16 - #34 - Determine filter; skip unsupported compression formats
+                var filterName = GetImageFilterName(image);
+                if (filterName is "JBIG2Decode" or "CCITTFaxDecode")
+                    continue;
+
+                byte[] bytes;
+                string mimeType;
+
+                if (filterName == "DCTDecode")
+                {
+                    // Argha - 2026-03-16 - #34 - DCTDecode = JPEG; RawBytes holds the encoded JPEG data
+                    bytes = image.RawBytes.ToArray();
+                    mimeType = "image/jpeg";
+                }
+                else
+                {
+                    // Argha - 2026-03-16 - #34 - All other encodings: attempt conversion to PNG via PdfPig
+                    if (!image.TryGetPng(out var png) || png is null)
+                        continue;
+
+                    bytes = png;
+                    mimeType = "image/png";
+                }
+
+                // Argha - 2026-03-16 - #34 - Skip images exceeding 20MB safety limit
+                const int MaxBytes = 20 * 1024 * 1024;
+                if (bytes.Length > MaxBytes)
+                    continue;
+
+                results.Add(new ExtractedImage(
+                    PageNumber: pageNumber,
+                    ImageIndex: imageIndex,
+                    Bytes: bytes,
+                    MimeType: mimeType,
+                    WidthPx: image.WidthInSamples,
+                    HeightPx: image.HeightInSamples));
+
+                imageIndex++;
+            }
+        }
+
+        return Task.FromResult(results);
+    }
+
+    // Argha - 2026-03-16 - #34 - Read the first filter name from ImageDictionary; returns null when no filter key exists
+    private static string? GetImageFilterName(IPdfImage image)
+    {
+        var dict = image.ImageDictionary;
+
+        if (!dict.TryGet(NameToken.Filter, out IToken? filterToken))
+            return null;
+
+        // Argha - 2026-03-16 - #34 - Filter may be a single name or an array; read the first entry
+        if (filterToken is NameToken nameTok)
+            return nameTok.Data;
+
+        if (filterToken is ArrayToken arrayTok && arrayTok.Data.Count > 0 && arrayTok.Data[0] is NameToken firstNameTok)
+            return firstNameTok.Data;
+
+        return null;
     }
 }

--- a/tests/RagApi.Tests/RagApi.Tests.csproj
+++ b/tests/RagApi.Tests/RagApi.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="PdfPig" Version="0.1.9" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>

--- a/tests/RagApi.Tests/Unit/Infrastructure/DocumentProcessorTests.cs
+++ b/tests/RagApi.Tests/Unit/Infrastructure/DocumentProcessorTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using RagApi.Application.Interfaces;
 using RagApi.Infrastructure.DocumentProcessing;
+using UglyToad.PdfPig.Writer;
 
 namespace RagApi.Tests.Unit.Infrastructure;
 
@@ -148,5 +149,39 @@ public class DocumentProcessorTests
         {
             chunks[i].ChunkIndex.Should().Be(i);
         }
+    }
+
+    // Argha - 2026-03-16 - #34 - ExtractImagesAsync tests: surface area and fast-path coverage
+
+    [Fact]
+    public async Task ExtractImagesAsync_PlainTextContentType_ReturnsEmpty()
+    {
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes("hello world"));
+        var result = await _sut.ExtractImagesAsync(stream, "text/plain");
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractImagesAsync_DocxContentType_ReturnsEmpty()
+    {
+        using var stream = new MemoryStream(new byte[] { 0x50, 0x4B, 0x03, 0x04 }); // ZIP magic bytes
+        var result = await _sut.ExtractImagesAsync(
+            stream,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractImagesAsync_TextOnlyPdf_ReturnsEmpty()
+    {
+        // Argha - 2026-03-16 - #34 - Build a minimal single-page text-only PDF with no embedded images
+        var builder = new PdfDocumentBuilder();
+        builder.AddPage(UglyToad.PdfPig.Content.PageSize.A4);
+        var pdfBytes = builder.Build();
+
+        using var stream = new MemoryStream(pdfBytes);
+        var result = await _sut.ExtractImagesAsync(stream, "application/pdf");
+
+        result.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
## Summary

- Adds `ExtractedImage` record and `ExtractImagesAsync` to `IDocumentProcessor` (Application layer)
- Implements PDF image extraction in `DocumentProcessor` using PdfPig (already installed)
  - Skips images smaller than 100×100 px (decorative/icons)
  - Skips `JBIG2Decode` and `CCITTFaxDecode` encoded images (unsupported)
  - Maps `DCTDecode` → `image/jpeg` using raw bytes; all others → `image/png` via `TryGetPng`
  - Skips images exceeding 20 MB
  - `ImageIndex` resets to 0 per page; `PageNumber` is 1-based
  - Non-PDF content types return `[]` silently (DOCX handled in #35)
- Adds `PdfPig 0.1.9` to test project; 3 new unit tests (304 total)

## Test plan

- [x] `ExtractImagesAsync_PlainTextContentType_ReturnsEmpty`
- [x] `ExtractImagesAsync_DocxContentType_ReturnsEmpty`
- [x] `ExtractImagesAsync_TextOnlyPdf_ReturnsEmpty`
- [x] Full test suite: 304 passing, 0 failed

Part of milestone: Phase 14 — Multimodal RAG

Closes #34