### PR TITLE
Add ExtractImagesFromDocxAsync — DOCX image extraction via OpenXml

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 [![Deploy](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml/badge.svg)](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml)
 ![.NET](https://img.shields.io/badge/.NET-8.0-512BD4?style=flat&logo=dotnet)
 ![C#](https://img.shields.io/badge/C%23-12-239120?style=flat&logo=csharp)
-![Tests](https://img.shields.io/badge/tests-304%20passing-brightgreen)
-![Phase](https://img.shields.io/badge/phase-14.4%20PDF%20image%20extraction-brightgreen)
+![Tests](https://img.shields.io/badge/tests-310%20passing-brightgreen)
+![Phase](https://img.shields.io/badge/phase-14.5%20DOCX%20image%20extraction-brightgreen)
 ![License](https://img.shields.io/badge/License-MIT-green.svg)
 
 ---
@@ -86,7 +86,7 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 - **GitHub Actions CI/CD** — Automated test, build, and deploy pipeline
 - **Azure deployment** — Container Apps (scales to zero) + Static Web Apps (free tier)
 - **Modern SaaS UI ✅** — Inter design system, indigo theme, drag-drop uploads, glassmorphism health dashboard, footer
-- **304 unit tests** — xUnit + Moq + FluentAssertions across all layers
+- **310 unit tests** — xUnit + Moq + FluentAssertions across all layers
 
 ---
 
@@ -300,7 +300,7 @@ Cors__AllowedOrigins__0=https://your-frontend.azurestaticapps.net
 | **Frontend** | Blazor WebAssembly (.NET 8) — Inter design system, indigo theme |
 | **Hosting** | Azure Container Apps + Azure Static Web Apps |
 | **CI/CD** | GitHub Actions → GHCR → Azure |
-| **Testing** | xUnit, Moq, FluentAssertions (304 tests) |
+| **Testing** | xUnit, Moq, FluentAssertions (310 tests) |
 | **API Docs** | Swagger / OpenAPI |
 
 ---
@@ -316,7 +316,7 @@ dotnet-rag-api/
 │   ├── RagApi.Domain/           # Core entities
 │   └── RagApi.Infrastructure/   # Qdrant, OpenAI, Azure, EF Core
 ├── tests/
-│   └── RagApi.Tests/            # 304 unit tests
+│   └── RagApi.Tests/            # 310 unit tests
 ├── .github/workflows/           # CI, Deploy API, Deploy UI
 ├── docker-compose.yml           # Local Qdrant + Ollama + PostgreSQL
 ├── Dockerfile                   # Production container image

--- a/src/RagApi.Application/Interfaces/IDocumentProcessor.cs
+++ b/src/RagApi.Application/Interfaces/IDocumentProcessor.cs
@@ -28,7 +28,7 @@ public interface IDocumentProcessor
     IReadOnlyList<string> SupportedContentTypes { get; }
 
     /// <summary>
-    /// Extract images from a document. Currently supports PDF only; returns empty list for all other content types.
+    /// Extract images from a document. Supports PDF (via PdfPig) and DOCX (via OpenXml ImageParts); returns empty list for all other content types.
     /// </summary>
     Task<List<ExtractedImage>> ExtractImagesAsync(Stream fileStream, string contentType, CancellationToken ct = default);
 }

--- a/src/RagApi.Infrastructure/DocumentProcessing/DocumentProcessor.cs
+++ b/src/RagApi.Infrastructure/DocumentProcessing/DocumentProcessor.cs
@@ -298,9 +298,15 @@ public class DocumentProcessor : IDocumentProcessor
         return await reader.ReadToEndAsync(cancellationToken);
     }
 
-    // Argha - 2026-03-16 - #34 - Extract images from PDF pages; non-PDF types return empty (DOCX handled in #35)
+    // Argha - 2026-03-16 - #34 - Extract images from a document; dispatches to PDF or DOCX handler
     public Task<List<ExtractedImage>> ExtractImagesAsync(Stream fileStream, string contentType, CancellationToken ct = default)
     {
+        // Argha - 2026-03-16 - #35 - DOCX branch; must be checked before the PDF guard
+        if (contentType.Equals(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            StringComparison.OrdinalIgnoreCase))
+            return ExtractImagesFromDocxAsync(fileStream);
+
         if (!contentType.Equals("application/pdf", StringComparison.OrdinalIgnoreCase))
             return Task.FromResult(new List<ExtractedImage>());
 
@@ -380,5 +386,109 @@ public class DocumentProcessor : IDocumentProcessor
             return firstNameTok.Data;
 
         return null;
+    }
+
+    // Argha - 2026-03-16 - #35 - Enumerate MainDocumentPart.ImageParts; DOCX images have no page numbers (PageNumber = 0)
+    private Task<List<ExtractedImage>> ExtractImagesFromDocxAsync(Stream fileStream)
+    {
+        var results = new List<ExtractedImage>();
+
+        using var document = WordprocessingDocument.Open(fileStream, false);
+        var mainPart = document.MainDocumentPart;
+        if (mainPart == null)
+            return Task.FromResult(results);
+
+        var imageIndex = 0;
+        const int MaxBytes = 20 * 1024 * 1024;
+
+        foreach (var imagePart in mainPart.ImageParts)
+        {
+            var mimeType = imagePart.ContentType;
+
+            byte[] bytes;
+            using (var imgStream = imagePart.GetStream())
+            using (var ms = new MemoryStream())
+            {
+                imgStream.CopyTo(ms);
+                bytes = ms.ToArray();
+            }
+
+            // Argha - 2026-03-16 - #35 - Reject images exceeding 20MB safety limit
+            if (bytes.Length > MaxBytes)
+                continue;
+
+            // Argha - 2026-03-16 - #35 - Apply 100x100 filter when dimensions are readable; include if unreadable
+            var (width, height) = TryGetImageDimensions(bytes, mimeType);
+            if (width.HasValue && height.HasValue && (width.Value < 100 || height.Value < 100))
+                continue;
+
+            results.Add(new ExtractedImage(
+                PageNumber: 0,
+                ImageIndex: imageIndex,
+                Bytes: bytes,
+                MimeType: mimeType,
+                WidthPx: width ?? 0,
+                HeightPx: height ?? 0));
+
+            imageIndex++;
+        }
+
+        return Task.FromResult(results);
+    }
+
+    // Argha - 2026-03-16 - #35 - Dispatch dimension reading by MIME type; returns (null,null) for unrecognised formats
+    private static (int? Width, int? Height) TryGetImageDimensions(byte[] bytes, string mimeType) =>
+        mimeType.ToLowerInvariant() switch
+        {
+            "image/png"                => ReadPngDimensions(bytes),
+            "image/jpeg" or "image/jpg" => ReadJpegDimensions(bytes),
+            "image/gif"                => ReadGifDimensions(bytes),
+            _                          => (null, null)
+        };
+
+    // Argha - 2026-03-16 - #35 - PNG IHDR: bytes 16–19 = width BE, bytes 20–23 = height BE
+    private static (int? Width, int? Height) ReadPngDimensions(byte[] bytes)
+    {
+        if (bytes.Length < 24 || bytes[0] != 0x89 || bytes[1] != 0x50 || bytes[2] != 0x4E || bytes[3] != 0x47)
+            return (null, null);
+
+        var w = (bytes[16] << 24) | (bytes[17] << 16) | (bytes[18] << 8) | bytes[19];
+        var h = (bytes[20] << 24) | (bytes[21] << 16) | (bytes[22] << 8) | bytes[23];
+        return (w, h);
+    }
+
+    // Argha - 2026-03-16 - #35 - JPEG: scan for SOF0 (FF C0) or SOF2 (FF C2); height at marker+5, width at marker+7
+    private static (int? Width, int? Height) ReadJpegDimensions(byte[] bytes)
+    {
+        if (bytes.Length < 4 || bytes[0] != 0xFF || bytes[1] != 0xD8)
+            return (null, null);
+
+        var i = 2;
+        while (i + 8 < bytes.Length)
+        {
+            if (bytes[i] != 0xFF) break;
+            var marker = bytes[i + 1];
+            var segLen = (bytes[i + 2] << 8) | bytes[i + 3];
+
+            if (marker == 0xC0 || marker == 0xC2)
+            {
+                var h = (bytes[i + 5] << 8) | bytes[i + 6];
+                var w = (bytes[i + 7] << 8) | bytes[i + 8];
+                return (w, h);
+            }
+            i += 2 + segLen;
+        }
+        return (null, null);
+    }
+
+    // Argha - 2026-03-16 - #35 - GIF header: bytes 6–7 = width LE, bytes 8–9 = height LE
+    private static (int? Width, int? Height) ReadGifDimensions(byte[] bytes)
+    {
+        if (bytes.Length < 10 || bytes[0] != 0x47 || bytes[1] != 0x49 || bytes[2] != 0x46)
+            return (null, null);
+
+        var w = bytes[6] | (bytes[7] << 8);
+        var h = bytes[8] | (bytes[9] << 8);
+        return (w, h);
     }
 }

--- a/tests/RagApi.Tests/Unit/Infrastructure/DocumentProcessorTests.cs
+++ b/tests/RagApi.Tests/Unit/Infrastructure/DocumentProcessorTests.cs
@@ -1,3 +1,6 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -164,11 +167,167 @@ public class DocumentProcessorTests
     [Fact]
     public async Task ExtractImagesAsync_DocxContentType_ReturnsEmpty()
     {
-        using var stream = new MemoryStream(new byte[] { 0x50, 0x4B, 0x03, 0x04 }); // ZIP magic bytes
+        // Argha - 2026-03-16 - #35 - Valid empty DOCX (no image parts) must return empty list
+        using var stream = new MemoryStream(CreateEmptyDocx());
         var result = await _sut.ExtractImagesAsync(
             stream,
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
         result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractImagesAsync_DocxWithPng100x100_ReturnsOneImage()
+    {
+        // Argha - 2026-03-16 - #35 - 100x100 PNG meets minimum threshold; must be returned
+        var pngBytes = MakeFakePngHeader(100, 100);
+        using var stream = new MemoryStream(CreateDocxWithImage(pngBytes, "image/png"));
+        var result = await _sut.ExtractImagesAsync(
+            stream,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        result.Should().HaveCount(1);
+        result[0].MimeType.Should().Be("image/png");
+        result[0].WidthPx.Should().Be(100);
+        result[0].HeightPx.Should().Be(100);
+        result[0].PageNumber.Should().Be(0);
+        result[0].ImageIndex.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExtractImagesAsync_DocxWithSmallPng_IsSkipped()
+    {
+        // Argha - 2026-03-16 - #35 - 50x50 PNG is below the 100x100 threshold; must be skipped
+        var smallPngBytes = MakeFakePngHeader(50, 50);
+        using var stream = new MemoryStream(CreateDocxWithImage(smallPngBytes, "image/png"));
+        var result = await _sut.ExtractImagesAsync(
+            stream,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractImagesAsync_DocxWithGif_HasGifMimeType()
+    {
+        // Argha - 2026-03-16 - #35 - GIF images must be included and carry image/gif MIME type
+        var gifBytes = MakeFakeGifHeader(200, 150);
+        using var stream = new MemoryStream(CreateDocxWithImage(gifBytes, "image/gif"));
+        var result = await _sut.ExtractImagesAsync(
+            stream,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        result.Should().HaveCount(1);
+        result[0].MimeType.Should().Be("image/gif");
+        result[0].WidthPx.Should().Be(200);
+        result[0].HeightPx.Should().Be(150);
+    }
+
+    [Fact]
+    public async Task ExtractImagesAsync_DocxWithUnreadableDimensions_IsIncluded()
+    {
+        // Argha - 2026-03-16 - #35 - BMP has no dimension reader; must be included (fail-open)
+        var bmpBytes = new byte[] { 0x42, 0x4D, 0x00, 0x00 };
+        using var stream = new MemoryStream(CreateDocxWithImage(bmpBytes, "image/bmp"));
+        var result = await _sut.ExtractImagesAsync(
+            stream,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        result.Should().HaveCount(1);
+        result[0].WidthPx.Should().Be(0);
+        result[0].HeightPx.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExtractImagesAsync_DocxWithMultipleImages_HasSequentialIndices()
+    {
+        // Argha - 2026-03-16 - #35 - Two 100x100 PNGs must get ImageIndex 0 and 1 respectively
+        var png1 = MakeFakePngHeader(100, 100);
+        var png2 = MakeFakePngHeader(200, 200);
+
+        using var ms = new MemoryStream();
+        using (var doc = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
+        {
+            var main = doc.AddMainDocumentPart();
+            main.Document = new Document(new Body(new Paragraph()));
+            foreach (var imgBytes in new[] { png1, png2 })
+            {
+                var part = main.AddImagePart("image/png");
+                using var imgMs = new MemoryStream(imgBytes);
+                part.FeedData(imgMs);
+            }
+            doc.Save();
+        }
+
+        using var stream = new MemoryStream(ms.ToArray());
+        var result = await _sut.ExtractImagesAsync(
+            stream,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+
+        result.Should().HaveCount(2);
+        result[0].ImageIndex.Should().Be(0);
+        result[1].ImageIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExtractImagesAsync_DocxWithOversizedImage_IsSkipped()
+    {
+        // Argha - 2026-03-16 - #35 - Image just over 20MB must be rejected by the safety limit
+        var oversizedBytes = new byte[20 * 1024 * 1024 + 1];
+        var header = MakeFakePngHeader(500, 500);
+        Array.Copy(header, oversizedBytes, header.Length);
+
+        using var stream = new MemoryStream(CreateDocxWithImage(oversizedBytes, "image/png"));
+        var result = await _sut.ExtractImagesAsync(
+            stream,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        result.Should().BeEmpty();
+    }
+
+    // Argha - 2026-03-16 - #35 - DOCX test helpers
+
+    private static byte[] CreateEmptyDocx()
+    {
+        using var ms = new MemoryStream();
+        using (var doc = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
+        {
+            var main = doc.AddMainDocumentPart();
+            main.Document = new Document(new Body(new Paragraph()));
+            doc.Save();
+        }
+        return ms.ToArray();
+    }
+
+    private static byte[] CreateDocxWithImage(byte[] imageBytes, string contentType)
+    {
+        using var ms = new MemoryStream();
+        using (var doc = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
+        {
+            var main = doc.AddMainDocumentPart();
+            main.Document = new Document(new Body(new Paragraph()));
+            var part = main.AddImagePart(contentType);
+            using var imgMs = new MemoryStream(imageBytes);
+            part.FeedData(imgMs);
+            doc.Save();
+        }
+        return ms.ToArray();
+    }
+
+    private static byte[] MakeFakePngHeader(int width, int height)
+    {
+        var b = new byte[32];
+        b[0]=0x89; b[1]=0x50; b[2]=0x4E; b[3]=0x47;
+        b[4]=0x0D; b[5]=0x0A; b[6]=0x1A; b[7]=0x0A;
+        b[8]=0; b[9]=0; b[10]=0; b[11]=13;
+        b[12]=0x49; b[13]=0x48; b[14]=0x44; b[15]=0x52;
+        b[16]=(byte)(width>>24); b[17]=(byte)(width>>16); b[18]=(byte)(width>>8); b[19]=(byte)width;
+        b[20]=(byte)(height>>24); b[21]=(byte)(height>>16); b[22]=(byte)(height>>8); b[23]=(byte)height;
+        return b;
+    }
+
+    private static byte[] MakeFakeGifHeader(int width, int height)
+    {
+        var b = new byte[10];
+        b[0]=0x47; b[1]=0x49; b[2]=0x46;
+        b[3]=0x38; b[4]=0x39; b[5]=0x61;
+        b[6]=(byte)(width&0xFF); b[7]=(byte)(width>>8);
+        b[8]=(byte)(height&0xFF); b[9]=(byte)(height>>8);
+        return b;
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Extends `ExtractImagesAsync` with a DOCX branch that enumerates `MainDocumentPart.ImageParts`
- Applies 100×100 size filter using lightweight PNG/JPEG/GIF header parsing (no new dependencies)
- 20MB safety cap; dimensions unreadable → fail-open (image included); `PageNumber = 0` for all DOCX images
- GIF images included with `image/gif` MIME type

## Test plan

- [x] `ExtractImagesAsync_DocxContentType_ReturnsEmpty` — updated to use valid empty DOCX
- [x] `ExtractImagesAsync_DocxWithPng100x100_ReturnsOneImage` — threshold boundary
- [x] `ExtractImagesAsync_DocxWithSmallPng_IsSkipped` — 50×50 filtered out
- [x] `ExtractImagesAsync_DocxWithGif_HasGifMimeType` — GIF MIME type preserved
- [x] `ExtractImagesAsync_DocxWithUnreadableDimensions_IsIncluded` — BMP fail-open
- [x] `ExtractImagesAsync_DocxWithMultipleImages_HasSequentialIndices` — sequential ImageIndex
- [x] `ExtractImagesAsync_DocxWithOversizedImage_IsSkipped` — 20MB cap enforced
- [x] 310/310 tests passing

Closes #35