### PR TITLE
Add vision ingestion pipeline to DocumentService

### DIFF
--- a/src/RagApi.Application/Services/DocumentService.cs
+++ b/src/RagApi.Application/Services/DocumentService.cs
@@ -19,21 +19,26 @@ public class DocumentService
     private readonly IVectorStore _vectorStore;
     private readonly ILogger<DocumentService> _logger;
     private readonly IDocumentRepository _documentRepository;
-    // Argha - 2026-02-20 - Default chunking options from config 
+    // Argha - 2026-02-20 - Default chunking options from config
     private readonly DocumentProcessingOptions _processingOptions;
 
-    // Argha - 2026-02-15 - Commented out: replaced with SQLite via IDocumentRepository 
+    // Argha - 2026-02-15 - Commented out: replaced with SQLite via IDocumentRepository
     // private static readonly ConcurrentDictionary<Guid, Document> _documents = new();
 
-    // Argha - 2026-02-21 - Batch upload options for concurrency and file count limits 
+    // Argha - 2026-02-21 - Batch upload options for concurrency and file count limits
     private readonly BatchUploadOptions _batchOptions;
 
     // Argha - 2026-03-04 - #17 - Workspace context provides the collection name for vector store isolation
     private readonly IWorkspaceContext _workspaceContext;
 
+    // Argha - 2026-03-17 - #36 - Vision service and image store; optional so existing tests compile unchanged
+    private readonly IVisionService? _visionService;
+    private readonly IImageStore? _imageStore;
+
     // Argha - 2026-02-20 - Added IOptions<DocumentProcessingOptions> for configurable chunking
     // Argha - 2026-02-21 - Added IOptions<BatchUploadOptions> for batch upload settings
     // Argha - 2026-03-04 - #17 - Added IWorkspaceContext for per-request collection name
+    // Argha - 2026-03-17 - #36 - Added optional IVisionService + IImageStore for multimodal ingestion
     public DocumentService(
         IDocumentProcessor documentProcessor,
         IEmbeddingService embeddingService,
@@ -42,7 +47,9 @@ public class DocumentService
         IDocumentRepository documentRepository,
         IOptions<DocumentProcessingOptions> processingOptions,
         IWorkspaceContext workspaceContext,
-        IOptions<BatchUploadOptions>? batchOptions = null)
+        IOptions<BatchUploadOptions>? batchOptions = null,
+        IVisionService? visionService = null,
+        IImageStore? imageStore = null)
     {
         _documentProcessor = documentProcessor;
         _embeddingService = embeddingService;
@@ -53,6 +60,8 @@ public class DocumentService
         _workspaceContext = workspaceContext;
         // Argha - 2026-02-21 - Optional to avoid breaking existing test constructors that don't pass it
         _batchOptions = batchOptions?.Value ?? new BatchUploadOptions();
+        _visionService = visionService;
+        _imageStore = imageStore;
     }
 
     /// <summary>
@@ -135,14 +144,32 @@ public class DocumentService
             // Argha - 2026-03-04 - #17 - Use workspace's collection name for tenant isolation
             await _vectorStore.UpsertChunksAsync(_workspaceContext.Current.CollectionName, chunks, cancellationToken);
 
+            // Argha - 2026-03-17 - #36 - Step 5 (best-effort): vision pipeline — describe and embed images
+            var imageChunks = new List<DocumentChunk>();
+            if (_visionService?.IsEnabled == true)
+            {
+                // Rewind: UploadDocumentAsync requires a seekable stream (MemoryStream from IFormFile satisfies this)
+                fileStream.Position = 0;
+                imageChunks = await RunVisionPipelineAsync(document.Id, fileName, contentType, normalizedTags, fileStream, cancellationToken);
+            }
+
+            if (imageChunks.Count > 0)
+            {
+                var descEmbeddings = await _embeddingService.GenerateEmbeddingsAsync(
+                    imageChunks.Select(c => c.Content).ToList(), cancellationToken);
+                for (int i = 0; i < imageChunks.Count; i++)
+                    imageChunks[i].Embedding = descEmbeddings[i];
+                await _vectorStore.UpsertChunksAsync(_workspaceContext.Current.CollectionName, imageChunks, cancellationToken);
+            }
+
             // Update document status
             document.Status = DocumentStatus.Completed;
-            document.ChunkCount = chunks.Count;
+            document.ChunkCount = chunks.Count + imageChunks.Count;
             await _documentRepository.UpdateAsync(document, cancellationToken);
 
             _logger.LogInformation(
-                "Document {DocumentId} processed successfully. {ChunkCount} chunks stored.",
-                document.Id, chunks.Count);
+                "Document {DocumentId} processed successfully. {ChunkCount} text chunks, {ImageChunkCount} image chunks stored.",
+                document.Id, chunks.Count, imageChunks.Count);
 
             return document;
         }
@@ -195,6 +222,10 @@ public class DocumentService
 
         try
         {
+            // Argha - 2026-03-17 - #36 - Remove stale image records before re-extracting
+            if (_imageStore != null)
+                await _imageStore.DeleteByDocumentAsync(documentId, cancellationToken);
+
             // Step 1: Remove old vectors so stale chunks don't remain in the index
             _logger.LogDebug("Deleting old chunks for document {DocumentId}", documentId);
             // Argha - 2026-03-04 - #17 - Use workspace's collection name for tenant isolation
@@ -243,20 +274,37 @@ public class DocumentService
             // Argha - 2026-03-04 - #17 - Use workspace's collection name for tenant isolation
             await _vectorStore.UpsertChunksAsync(_workspaceContext.Current.CollectionName, chunks, cancellationToken);
 
+            // Argha - 2026-03-17 - #36 - Step 5b (best-effort): vision pipeline for updated document
+            var imageChunks = new List<DocumentChunk>();
+            if (_visionService?.IsEnabled == true)
+            {
+                fileStream.Position = 0;
+                imageChunks = await RunVisionPipelineAsync(documentId, fileName, contentType, normalizedTags, fileStream, cancellationToken);
+            }
+
+            if (imageChunks.Count > 0)
+            {
+                var descEmbeddings = await _embeddingService.GenerateEmbeddingsAsync(
+                    imageChunks.Select(c => c.Content).ToList(), cancellationToken);
+                for (int i = 0; i < imageChunks.Count; i++)
+                    imageChunks[i].Embedding = descEmbeddings[i];
+                await _vectorStore.UpsertChunksAsync(_workspaceContext.Current.CollectionName, imageChunks, cancellationToken);
+            }
+
             // Step 6: Persist updated metadata
             document.FileName = fileName;
             document.ContentType = contentType;
             document.FileSize = fileStream.Length;
             document.TagsJson = JsonSerializer.Serialize(normalizedTags);
             document.Status = DocumentStatus.Completed;
-            document.ChunkCount = chunks.Count;
+            document.ChunkCount = chunks.Count + imageChunks.Count;
             document.UpdatedAt = DateTime.UtcNow;
             document.ErrorMessage = null;
             await _documentRepository.UpdateAsync(document, cancellationToken);
 
             _logger.LogInformation(
-                "Document {DocumentId} re-processed successfully. {ChunkCount} chunks stored.",
-                documentId, chunks.Count);
+                "Document {DocumentId} re-processed successfully. {ChunkCount} text chunks, {ImageChunkCount} image chunks stored.",
+                documentId, chunks.Count, imageChunks.Count);
 
             return document;
         }
@@ -308,6 +356,10 @@ public class DocumentService
     {
         _logger.LogInformation("Deleting document {DocumentId}", documentId);
 
+        // Argha - 2026-03-17 - #36 - Remove image records before vector chunks
+        if (_imageStore != null)
+            await _imageStore.DeleteByDocumentAsync(documentId, cancellationToken);
+
         // Remove chunks from vector store
         // Argha - 2026-03-04 - #17 - Use workspace's collection name for tenant isolation
         await _vectorStore.DeleteDocumentChunksAsync(_workspaceContext.Current.CollectionName, documentId, cancellationToken);
@@ -317,6 +369,90 @@ public class DocumentService
         await _documentRepository.DeleteAsync(documentId, cancellationToken);
 
         _logger.LogInformation("Document {DocumentId} deleted successfully", documentId);
+    }
+
+    // Argha - 2026-03-17 - #36 - Best-effort: describe each extracted image with the vision service,
+    // persist bytes to the image store, and return one DocumentChunk per image.
+    // Individual image failures are logged and skipped — the whole upload is never failed by vision errors.
+    private async Task<List<DocumentChunk>> RunVisionPipelineAsync(
+        Guid documentId,
+        string fileName,
+        string contentType,
+        List<string> tags,
+        Stream fileStream,
+        CancellationToken cancellationToken)
+    {
+        List<ExtractedImage> images;
+        try
+        {
+            images = await _documentProcessor.ExtractImagesAsync(fileStream, contentType, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Vision pipeline: image extraction failed for document {DocumentId} — skipping", documentId);
+            return new List<DocumentChunk>();
+        }
+
+        if (images.Count == 0)
+            return new List<DocumentChunk>();
+
+        _logger.LogInformation("Vision pipeline: {Count} images found in document {DocumentId}", images.Count, documentId);
+
+        var chunks = new List<DocumentChunk>();
+        int succeeded = 0;
+
+        foreach (var image in images)
+        {
+            try
+            {
+                var description = await _visionService!.DescribeImageAsync(
+                    image.Bytes, image.MimeType, context: fileName, ct: cancellationToken);
+
+                var docImage = new DocumentImage
+                {
+                    DocumentId = documentId,
+                    WorkspaceId = _workspaceContext.Current.Id,
+                    PageNumber = image.PageNumber > 0 ? image.PageNumber : null,
+                    ContentType = image.MimeType,
+                    Data = image.Bytes,
+                    AiDescription = description,
+                    CreatedAt = DateTime.UtcNow
+                };
+                var imageId = await _imageStore!.SaveAsync(docImage, cancellationToken);
+
+                var chunk = new DocumentChunk
+                {
+                    DocumentId = documentId,
+                    Content = description,
+                    ChunkIndex = image.ImageIndex,
+                    IsImageChunk = true,
+                    ImageId = imageId,
+                    Tags = tags,
+                    Metadata = new Dictionary<string, string>
+                    {
+                        ["fileName"] = fileName,
+                        ["contentType"] = contentType,
+                        ["isImage"] = "true",
+                        ["imageId"] = imageId.ToString(),
+                        ["pageNumber"] = image.PageNumber.ToString()
+                    }
+                };
+                chunks.Add(chunk);
+                succeeded++;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Vision pipeline: failed to process image {Index} (page {Page}) for document {DocumentId} — skipping",
+                    image.ImageIndex, image.PageNumber, documentId);
+            }
+        }
+
+        _logger.LogInformation(
+            "Vision pipeline: {Succeeded}/{Total} images processed for document {DocumentId}",
+            succeeded, images.Count, documentId);
+
+        return chunks;
     }
 
     /// <summary>

--- a/src/RagApi.Domain/Entities/DocumentChunk.cs
+++ b/src/RagApi.Domain/Entities/DocumentChunk.cs
@@ -14,6 +14,13 @@ public class DocumentChunk
     public float[]? Embedding { get; set; }
     public Dictionary<string, string> Metadata { get; set; } = new();
 
-    // Argha - 2026-02-19 - Tags propagated from parent document for Qdrant payload filtering 
+    // Argha - 2026-02-19 - Tags propagated from parent document for Qdrant payload filtering
     public List<string> Tags { get; set; } = new();
+
+    // Argha - 2026-03-17 - #36 - Set when this chunk was produced by the vision pipeline;
+    // ImageId links to the DocumentImages table so callers can fetch the raw image bytes
+    public Guid? ImageId { get; set; }
+
+    // Argha - 2026-03-17 - #36 - True for image-description chunks; false for all text chunks
+    public bool IsImageChunk { get; set; }
 }

--- a/tests/RagApi.Tests/Unit/Services/DocumentServiceTests.cs
+++ b/tests/RagApi.Tests/Unit/Services/DocumentServiceTests.cs
@@ -419,3 +419,276 @@ public class DocumentServiceTests
             It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }
 }
+
+// Argha - 2026-03-17 - #36 - Vision ingestion pipeline tests (separate fixture so existing tests stay unchanged)
+public class DocumentServiceVisionPipelineTests
+{
+    private readonly Mock<IDocumentProcessor> _processorMock = new();
+    private readonly Mock<IEmbeddingService> _embeddingMock = new();
+    private readonly Mock<IVectorStore> _vectorStoreMock = new();
+    private readonly Mock<ILogger<DocumentService>> _loggerMock = new();
+    private readonly Mock<IDocumentRepository> _repositoryMock = new();
+    private readonly Mock<IVisionService> _visionMock = new();
+    private readonly Mock<IImageStore> _imageStoreMock = new();
+    private readonly Mock<IWorkspaceContext> _workspaceContextMock = new();
+
+    private const string TestCollection = "documents";
+
+    public DocumentServiceVisionPipelineTests()
+    {
+        _processorMock.Setup(p => p.IsSupported("application/pdf")).Returns(true);
+        _processorMock.Setup(p => p.SupportedContentTypes)
+            .Returns(new[] { "text/plain", "application/pdf" });
+
+        _workspaceContextMock.Setup(w => w.Current).Returns(new Workspace
+        {
+            Id = Workspace.DefaultWorkspaceId,
+            CollectionName = TestCollection
+        });
+    }
+
+    private DocumentService BuildSut(bool visionEnabled = true)
+    {
+        _visionMock.Setup(v => v.IsEnabled).Returns(visionEnabled);
+        return new DocumentService(
+            _processorMock.Object,
+            _embeddingMock.Object,
+            _vectorStoreMock.Object,
+            _loggerMock.Object,
+            _repositoryMock.Object,
+            Options.Create(new DocumentProcessingOptions()),
+            _workspaceContextMock.Object,
+            visionService: _visionMock.Object,
+            imageStore: _imageStoreMock.Object);
+    }
+
+    private void SetupTextPipeline(string text = "some text")
+    {
+        _processorMock.Setup(p => p.ExtractTextAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(text);
+        _processorMock.Setup(p => p.ChunkText(It.IsAny<Guid>(), text, It.IsAny<ChunkingOptions?>()))
+            .Returns(new List<DocumentChunk> { new() { Content = text, Metadata = new() } });
+        _embeddingMock.Setup(e => e.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<string> texts, CancellationToken _) =>
+                texts.Select(_ => new float[768]).ToList());
+    }
+
+    private static ExtractedImage MakeImage(int page = 1, int index = 0) =>
+        new(PageNumber: page, ImageIndex: index, Bytes: new byte[] { 1, 2, 3 },
+            MimeType: "image/png", WidthPx: 200, HeightPx: 200);
+
+    // ── Upload: happy path ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Upload_VisionEnabled_CallsDescribeForEachImage()
+    {
+        // Arrange
+        var sut = BuildSut();
+        SetupTextPipeline();
+        var images = new List<ExtractedImage> { MakeImage(1, 0), MakeImage(2, 1) };
+        _processorMock.Setup(p => p.ExtractImagesAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(images);
+        _visionMock.Setup(v => v.DescribeImageAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("A diagram");
+        _imageStoreMock.Setup(s => s.SaveAsync(It.IsAny<DocumentImage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+        using var stream = new MemoryStream(new byte[10]);
+
+        // Act
+        await sut.UploadDocumentAsync(stream, "doc.pdf", "application/pdf");
+
+        // Assert
+        _visionMock.Verify(v => v.DescribeImageAsync(It.IsAny<byte[]>(), "image/png", "doc.pdf", It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Upload_VisionEnabled_SavesImageForEachExtractedImage()
+    {
+        // Arrange
+        var sut = BuildSut();
+        SetupTextPipeline();
+        _processorMock.Setup(p => p.ExtractImagesAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ExtractedImage> { MakeImage() });
+        _visionMock.Setup(v => v.DescribeImageAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("A chart");
+        _imageStoreMock.Setup(s => s.SaveAsync(It.IsAny<DocumentImage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+        using var stream = new MemoryStream(new byte[10]);
+
+        // Act
+        await sut.UploadDocumentAsync(stream, "report.pdf", "application/pdf");
+
+        // Assert
+        _imageStoreMock.Verify(s => s.SaveAsync(
+            It.Is<DocumentImage>(img =>
+                img.DocumentId != Guid.Empty &&
+                img.WorkspaceId == Workspace.DefaultWorkspaceId &&
+                img.AiDescription == "A chart"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Upload_VisionEnabled_UpsertsImageChunkWithIsImageTrue()
+    {
+        // Arrange
+        var sut = BuildSut();
+        SetupTextPipeline();
+        var imageId = Guid.NewGuid();
+        _processorMock.Setup(p => p.ExtractImagesAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ExtractedImage> { MakeImage() });
+        _visionMock.Setup(v => v.DescribeImageAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Flowchart");
+        _imageStoreMock.Setup(s => s.SaveAsync(It.IsAny<DocumentImage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(imageId);
+        var capturedChunks = new List<DocumentChunk>();
+        _vectorStoreMock.Setup(v => v.UpsertChunksAsync(It.IsAny<string>(), It.IsAny<List<DocumentChunk>>(), It.IsAny<CancellationToken>()))
+            .Callback<string, List<DocumentChunk>, CancellationToken>((_, c, _) => capturedChunks.AddRange(c))
+            .Returns(Task.CompletedTask);
+        using var stream = new MemoryStream(new byte[10]);
+
+        // Act
+        await sut.UploadDocumentAsync(stream, "manual.pdf", "application/pdf");
+
+        // Assert: second UpsertChunksAsync call contains the image chunk
+        var imageChunk = capturedChunks.FirstOrDefault(c => c.IsImageChunk);
+        imageChunk.Should().NotBeNull();
+        imageChunk!.ImageId.Should().Be(imageId);
+        imageChunk.Content.Should().Be("Flowchart");
+        imageChunk.Metadata["isImage"].Should().Be("true");
+        imageChunk.Metadata["imageId"].Should().Be(imageId.ToString());
+    }
+
+    [Fact]
+    public async Task Upload_VisionEnabled_ChunkCountIncludesImageChunks()
+    {
+        // Arrange
+        var sut = BuildSut();
+        SetupTextPipeline();
+        _processorMock.Setup(p => p.ExtractImagesAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ExtractedImage> { MakeImage(1, 0), MakeImage(2, 1) });
+        _visionMock.Setup(v => v.DescribeImageAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("description");
+        _imageStoreMock.Setup(s => s.SaveAsync(It.IsAny<DocumentImage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+        using var stream = new MemoryStream(new byte[10]);
+
+        // Act
+        var result = await sut.UploadDocumentAsync(stream, "doc.pdf", "application/pdf");
+
+        // Assert: 1 text chunk + 2 image chunks
+        result.ChunkCount.Should().Be(3);
+    }
+
+    // ── Upload: vision disabled ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task Upload_VisionDisabled_DoesNotExtractImages()
+    {
+        // Arrange
+        var sut = BuildSut(visionEnabled: false);
+        SetupTextPipeline();
+        using var stream = new MemoryStream(new byte[10]);
+
+        // Act
+        await sut.UploadDocumentAsync(stream, "doc.pdf", "application/pdf");
+
+        // Assert
+        _processorMock.Verify(p => p.ExtractImagesAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _imageStoreMock.Verify(s => s.SaveAsync(It.IsAny<DocumentImage>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── Upload: best-effort failure isolation ───────────────────────────────
+
+    [Fact]
+    public async Task Upload_OneImageDescriptionFails_OtherImagesStillProcessed()
+    {
+        // Arrange
+        var sut = BuildSut();
+        SetupTextPipeline();
+        _processorMock.Setup(p => p.ExtractImagesAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ExtractedImage> { MakeImage(1, 0), MakeImage(2, 1) });
+        // First image fails, second succeeds
+        var callCount = 0;
+        _visionMock.Setup(v => v.DescribeImageAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                if (callCount == 1) throw new Exception("Vision API timeout");
+                return "Second image description";
+            });
+        _imageStoreMock.Setup(s => s.SaveAsync(It.IsAny<DocumentImage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+        using var stream = new MemoryStream(new byte[10]);
+
+        // Act — must not throw
+        var result = await sut.UploadDocumentAsync(stream, "doc.pdf", "application/pdf");
+
+        // Assert: 1 text + 1 image chunk (second image only)
+        result.Status.Should().Be(DocumentStatus.Completed);
+        result.ChunkCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Upload_ImageExtractionThrows_DocumentStillCompletes()
+    {
+        // Arrange
+        var sut = BuildSut();
+        SetupTextPipeline();
+        _processorMock.Setup(p => p.ExtractImagesAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("PDF parse error"));
+        using var stream = new MemoryStream(new byte[10]);
+
+        // Act — must not throw
+        var result = await sut.UploadDocumentAsync(stream, "doc.pdf", "application/pdf");
+
+        // Assert
+        result.Status.Should().Be(DocumentStatus.Completed);
+        _imageStoreMock.Verify(s => s.SaveAsync(It.IsAny<DocumentImage>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── Delete: cascade to image store ─────────────────────────────────────
+
+    [Fact]
+    public async Task Delete_CallsImageStoreDeleteBeforeVectorStore()
+    {
+        // Arrange
+        var sut = BuildSut();
+        var docId = Guid.NewGuid();
+        var callOrder = new List<string>();
+        _imageStoreMock.Setup(s => s.DeleteByDocumentAsync(docId, It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("imageStore"))
+            .Returns(Task.CompletedTask);
+        _vectorStoreMock.Setup(v => v.DeleteDocumentChunksAsync(It.IsAny<string>(), docId, It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("vectorStore"))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await sut.DeleteDocumentAsync(docId);
+
+        // Assert
+        _imageStoreMock.Verify(s => s.DeleteByDocumentAsync(docId, It.IsAny<CancellationToken>()), Times.Once);
+        callOrder.Should().Equal("imageStore", "vectorStore");
+    }
+
+    // ── Update: stale image cleanup ─────────────────────────────────────────
+
+    [Fact]
+    public async Task Update_DeletesOldImagesBeforeReprocessing()
+    {
+        // Arrange
+        var sut = BuildSut(visionEnabled: false); // keep it simple — just verify cleanup
+        var docId = Guid.NewGuid();
+        var existingDoc = new Document { Id = docId, FileName = "old.pdf" };
+        _repositoryMock.Setup(r => r.GetByIdAsync(docId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingDoc);
+        SetupTextPipeline();
+        _processorMock.Setup(p => p.IsSupported("application/pdf")).Returns(true);
+        using var stream = new MemoryStream(new byte[10]);
+
+        // Act
+        await sut.UpdateDocumentAsync(docId, stream, "new.pdf", "application/pdf");
+
+        // Assert
+        _imageStoreMock.Verify(s => s.DeleteByDocumentAsync(docId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary

- Wires `IVisionService` + `IImageStore` into `DocumentService` — both injected as optional constructor params so all existing tests compile unchanged
- `UploadDocumentAsync`: after text chunking, rewinds stream → `ExtractImagesAsync` → per image: `DescribeImageAsync` → `SaveAsync` → build `DocumentChunk` with `IsImageChunk=true` and `ImageId` set → embed descriptions → upsert to Qdrant
- Image processing is best-effort: per-image failures are logged and skipped; extraction failure also skipped — the document upload never fails due to vision errors
- `UpdateDocumentAsync`: deletes stale image records via `IImageStore.DeleteByDocumentAsync` before re-processing, then runs vision pipeline on new content
- `DeleteDocumentAsync`: cascades to `IImageStore.DeleteByDocumentAsync` before vector chunk deletion
- `DocumentChunk` gains typed `Guid? ImageId` and `bool IsImageChunk` properties (metadata dict also populated for Qdrant payload)

## Test plan

- [x] `Upload_VisionEnabled_CallsDescribeForEachImage`
- [x] `Upload_VisionEnabled_SavesImageForEachExtractedImage`
- [x] `Upload_VisionEnabled_UpsertsImageChunkWithIsImageTrue`
- [x] `Upload_VisionEnabled_ChunkCountIncludesImageChunks`
- [x] `Upload_VisionDisabled_DoesNotExtractImages`
- [x] `Upload_OneImageDescriptionFails_OtherImagesStillProcessed`
- [x] `Upload_ImageExtractionThrows_DocumentStillCompletes`
- [x] `Delete_CallsImageStoreDeleteBeforeVectorStore`
- [x] `Update_DeletesOldImagesBeforeReprocessing`
- [x] Full suite: 319 tests, 0 failures

Part of #29 — Closes #36