### PR TITLE
[FEATURE] #38 API models: SourceDto image reference fields

### DIFF
--- a/src/RagApi.Api/Controllers/ChatController.cs
+++ b/src/RagApi.Api/Controllers/ChatController.cs
@@ -106,7 +106,10 @@ public class ChatController : ControllerBase
                 DocumentId = s.DocumentId,
                 FileName = s.FileName,
                 RelevantText = s.RelevantText,
-                RelevanceScore = s.RelevanceScore
+                RelevanceScore = s.RelevanceScore,
+                // Argha - 2026-03-17 - #38 - Forward image fields so client can fetch raw image bytes
+                ImageId = s.ImageId,
+                IsImage = s.IsImage
             }).ToList()
         };
 

--- a/src/RagApi.Api/Models/ApiModels.cs
+++ b/src/RagApi.Api/Models/ApiModels.cs
@@ -106,6 +106,9 @@ public class SourceDto
     public string FileName { get; set; } = string.Empty;
     public string RelevantText { get; set; } = string.Empty;
     public double RelevanceScore { get; set; }
+    // Argha - 2026-03-17 - #38 - Image reference fields so UI can construct GET /api/images/{id} URL
+    public Guid? ImageId { get; set; }
+    public bool IsImage { get; set; }
 }
 
 /// <summary>

--- a/src/RagApi.Application/Services/RagService.cs
+++ b/src/RagApi.Application/Services/RagService.cs
@@ -118,7 +118,10 @@ Remember: Only use information from the context above. Do not make up informatio
                 FileName = r.FileName,
                 RelevantText = TruncateText(r.Content, 200),
                 RelevanceScore = r.Score,
-                ChunkIndex = r.ChunkIndex
+                ChunkIndex = r.ChunkIndex,
+                // Argha - 2026-03-17 - #38 - Propagate image metadata from chunk so API and UI can render images inline
+                IsImage = r.Metadata.TryGetValue("isImage", out var isImg) && isImg == "true",
+                ImageId = r.Metadata.TryGetValue("imageId", out var imgId) && Guid.TryParse(imgId, out var parsedId) ? parsedId : null
             }).ToList(),
             Model = _chatService.ModelName
         };
@@ -155,7 +158,10 @@ Remember: Only use information from the context above. Do not make up informatio
             FileName = r.FileName,
             RelevantText = TruncateText(r.Content, 200),
             RelevanceScore = r.Score,
-            ChunkIndex = r.ChunkIndex
+            ChunkIndex = r.ChunkIndex,
+            // Argha - 2026-03-17 - #38 - Propagate image metadata from chunk so API and UI can render images inline
+            IsImage = r.Metadata.TryGetValue("isImage", out var isImg) && isImg == "true",
+            ImageId = r.Metadata.TryGetValue("imageId", out var imgId) && Guid.TryParse(imgId, out var parsedId) ? parsedId : null
         }).ToList();
 
         // Argha - 2026-02-19 - Yield sources first so the client can render citations while tokens stream in

--- a/src/RagApi.BlazorUI/Models/ChatModels.cs
+++ b/src/RagApi.BlazorUI/Models/ChatModels.cs
@@ -24,6 +24,9 @@ public class SourceCitationDto
     public string RelevantText { get; set; } = string.Empty;
     public double RelevanceScore { get; set; }
     public int ChunkIndex { get; set; }
+    // Argha - 2026-03-17 - #38 - Image reference fields so UI can construct GET /api/images/{id} URL
+    public Guid? ImageId { get; set; }
+    public bool IsImage { get; set; }
 }
 
 public class SearchRequest

--- a/src/RagApi.Domain/Entities/ChatMessage.cs
+++ b/src/RagApi.Domain/Entities/ChatMessage.cs
@@ -31,4 +31,7 @@ public class SourceCitation
     public string RelevantText { get; set; } = string.Empty;
     public double RelevanceScore { get; set; }
     public int ChunkIndex { get; set; }
+    // Argha - 2026-03-17 - #38 - Image reference fields so UI can fetch raw image bytes
+    public Guid? ImageId { get; set; }
+    public bool IsImage { get; set; }
 }

--- a/tests/RagApi.Tests/Unit/Api/ChatControllerTests.cs
+++ b/tests/RagApi.Tests/Unit/Api/ChatControllerTests.cs
@@ -332,6 +332,35 @@ public class ChatControllerTests
         _vectorStoreMock.Verify(v => v.SearchAsync(It.IsAny<string>(), TestEmbedding, 5, null, tags, It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    // Argha - 2026-03-17 - #38 - SourceDto image field mapping test
+    [Fact]
+    public async Task Chat_MapsImageFieldsFromSourceCitationToSourceDto()
+    {
+        // Arrange
+        var imageId = Guid.NewGuid();
+        var searchResults = new List<SearchResult>
+        {
+            new()
+            {
+                ChunkId = Guid.NewGuid(), DocumentId = Guid.NewGuid(), FileName = "manual.pdf",
+                Content = "Figure description", Score = 0.9, ChunkIndex = 0,
+                Metadata = new Dictionary<string, string> { ["isImage"] = "true", ["imageId"] = imageId.ToString() }
+            }
+        };
+        _vectorStoreMock.Setup(v => v.SearchAsync(It.IsAny<string>(), It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<Guid?>(), It.IsAny<List<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(searchResults);
+        _chatMock.Setup(c => c.GenerateResponseAsync(It.IsAny<string>(), It.IsAny<List<ChatMessage>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Answer");
+
+        // Act
+        var result = await _sut.Chat(new ChatRequest { Query = "test" }, CancellationToken.None);
+
+        // Assert
+        var dto = ((OkObjectResult)result).Value as ChatResponseDto;
+        dto!.Sources[0].IsImage.Should().BeTrue();
+        dto.Sources[0].ImageId.Should().Be(imageId);
+    }
+
     // Argha - 2026-02-19 - Overload without explicit cancellation token for call-site convenience
     private static async IAsyncEnumerable<string> CreateTestTokenStream(params string[] tokens)
     {

--- a/tests/RagApi.Tests/Unit/Services/RagServiceTests.cs
+++ b/tests/RagApi.Tests/Unit/Services/RagServiceTests.cs
@@ -323,6 +323,93 @@ public class RagServiceTests
         }
     }
 
+    // Argha - 2026-03-17 - #38 - Image metadata mapping tests for SourceCitation
+
+    [Fact]
+    public async Task ChatAsync_WithImageChunkMetadata_MapsImageIdAndIsImageOnSource()
+    {
+        // Arrange
+        var imageId = Guid.NewGuid();
+        var searchResults = new List<SearchResult>
+        {
+            new()
+            {
+                ChunkId = Guid.NewGuid(), DocumentId = Guid.NewGuid(), FileName = "manual.pdf",
+                Content = "Figure 1 description", Score = 0.95, ChunkIndex = 0,
+                Metadata = new Dictionary<string, string> { ["isImage"] = "true", ["imageId"] = imageId.ToString() }
+            }
+        };
+        _vectorStoreMock.Setup(v => v.SearchAsync(It.IsAny<string>(), It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<Guid?>(), It.IsAny<List<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(searchResults);
+        _chatServiceMock.Setup(c => c.GenerateResponseAsync(It.IsAny<string>(), It.IsAny<List<ChatMessage>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Answer");
+
+        // Act
+        var result = await _sut.ChatAsync("show me the figure");
+
+        // Assert
+        result.Sources[0].IsImage.Should().BeTrue();
+        result.Sources[0].ImageId.Should().Be(imageId);
+    }
+
+    [Fact]
+    public async Task ChatAsync_WithTextChunkMetadata_HasNullImageIdAndFalseIsImage()
+    {
+        // Arrange
+        var searchResults = new List<SearchResult>
+        {
+            new()
+            {
+                ChunkId = Guid.NewGuid(), DocumentId = Guid.NewGuid(), FileName = "doc.txt",
+                Content = "Some text content", Score = 0.9, ChunkIndex = 0,
+                Metadata = new Dictionary<string, string>()
+            }
+        };
+        _vectorStoreMock.Setup(v => v.SearchAsync(It.IsAny<string>(), It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<Guid?>(), It.IsAny<List<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(searchResults);
+        _chatServiceMock.Setup(c => c.GenerateResponseAsync(It.IsAny<string>(), It.IsAny<List<ChatMessage>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Answer");
+
+        // Act
+        var result = await _sut.ChatAsync("query");
+
+        // Assert
+        result.Sources[0].IsImage.Should().BeFalse();
+        result.Sources[0].ImageId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ChatStreamAsync_WithImageChunkMetadata_MapsImageIdAndIsImageOnSource()
+    {
+        // Arrange
+        var imageId = Guid.NewGuid();
+        var searchResults = new List<SearchResult>
+        {
+            new()
+            {
+                ChunkId = Guid.NewGuid(), DocumentId = Guid.NewGuid(), FileName = "manual.pdf",
+                Content = "Diagram description", Score = 0.95, ChunkIndex = 0,
+                Metadata = new Dictionary<string, string> { ["isImage"] = "true", ["imageId"] = imageId.ToString() }
+            }
+        };
+        _vectorStoreMock.Setup(v => v.SearchAsync(It.IsAny<string>(), It.IsAny<float[]>(), It.IsAny<int>(), It.IsAny<Guid?>(), It.IsAny<List<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(searchResults);
+        _chatServiceMock.Setup(c => c.GenerateResponseStreamAsync(It.IsAny<string>(), It.IsAny<List<ChatMessage>>(), It.IsAny<CancellationToken>()))
+            .Returns(CreateTestTokenStream("Answer"));
+
+        // Act
+        StreamEvent? sourcesEvent = null;
+        await foreach (var evt in _sut.ChatStreamAsync("show me the diagram"))
+        {
+            if (evt.Type == "sources") sourcesEvent = evt;
+        }
+
+        // Assert
+        sourcesEvent.Should().NotBeNull();
+        sourcesEvent!.Sources![0].IsImage.Should().BeTrue();
+        sourcesEvent.Sources[0].ImageId.Should().Be(imageId);
+    }
+
     private static List<SearchResult> CreateSearchResults(int count)
     {
         return Enumerable.Range(0, count).Select(i => new SearchResult
@@ -332,7 +419,8 @@ public class RagServiceTests
             FileName = $"doc{i}.txt",
             Content = $"Content of chunk {i}",
             Score = 0.9 - (i * 0.1),
-            ChunkIndex = i
+            ChunkIndex = i,
+            Metadata = new Dictionary<string, string>()
         }).ToList();
     }
 }


### PR DESCRIPTION
## Summary

- Added `ImageId` (`Guid?`) and `IsImage` (`bool`) to `SourceCitation` (Domain), `SourceDto` (API), and `SourceCitationDto` (BlazorUI)
- `RagService` reads `isImage` / `imageId` from `SearchResult.Metadata` in both `ChatAsync` and `ChatStreamAsync`
- `ChatController` forwards the new fields in the `SourceCitation → SourceDto` mapping
- `SourceCitationDto` receives the fields via SSE (camelCase JSON) and REST deserialization automatically

Part of Phase 14 multimodal RAG (#29). Closes #38.

## Test plan

- [x] `RagServiceTests.ChatAsync_WithImageChunkMetadata_MapsImageIdAndIsImageOnSource`
- [x] `RagServiceTests.ChatAsync_WithTextChunkMetadata_HasNullImageIdAndFalseIsImage`
- [x] `RagServiceTests.ChatStreamAsync_WithImageChunkMetadata_MapsImageIdAndIsImageOnSource`
- [x] `ChatControllerTests.Chat_MapsImageFieldsFromSourceCitationToSourceDto`
- [x] All 328 existing tests pass (4 pre-existing Postgres integration tests require a live DB — excluded from CI)