### PR TITLE
Remove SWA PR preview triggers

### DIFF
--- a/.github/workflows/swa-deploy.yml
+++ b/.github/workflows/swa-deploy.yml
@@ -4,13 +4,9 @@ name: Deploy Blazor UI
 on:
   push:
     branches: [ main ]
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches: [ main ]
 
 jobs:
   build_and_deploy:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Blazor UI
 
@@ -26,15 +22,3 @@ jobs:
           app_location: src/RagApi.BlazorUI
           api_location: ""
           output_location: wwwroot
-
-  close_pull_request:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request
-
-    steps:
-      - name: Close Pull Request
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
-          action: close


### PR DESCRIPTION
## Summary
- Remove `pull_request` trigger and `close_pull_request` job from `swa-deploy.yml`
- PR preview deployments are unused; the closed PR event was triggering a redundant 4th workflow run on every merge
- Deploy on `push` to `main` only