### PR TITLE
Fix vision pipeline disabled and CCITT images skipped (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 [![Deploy](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml/badge.svg)](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml)
 ![.NET](https://img.shields.io/badge/.NET-8.0-512BD4?style=flat&logo=dotnet)
 ![C#](https://img.shields.io/badge/C%23-12-239120?style=flat&logo=csharp)
-![Tests](https://img.shields.io/badge/tests-328%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-330%20passing-brightgreen)
 ![Phase](https://img.shields.io/badge/phase-14.8%20image%20sources%20UI-brightgreen)
 ![License](https://img.shields.io/badge/License-MIT-green.svg)
 

--- a/src/RagApi.Api/appsettings.json
+++ b/src/RagApi.Api/appsettings.json
@@ -124,7 +124,8 @@
   },
 
   "Vision": {
-    "Enabled": false,
-    "Model": "gpt-4o-mini"
+    "Enabled": true,
+    "Model": "gpt-4o-mini",
+    "MaxImagesPerDocument": 20
   }
 }

--- a/src/RagApi.Application/Models/VisionOptions.cs
+++ b/src/RagApi.Application/Models/VisionOptions.cs
@@ -1,0 +1,10 @@
+namespace RagApi.Application.Models;
+
+// Argha - 2026-03-18 - #52 - Application-layer vision options; mirrors relevant fields from Infrastructure VisionConfiguration
+public class VisionOptions
+{
+    public const string SectionName = "Vision";
+
+    // Argha - 2026-03-18 - #52 - Cap GPT-4o-mini calls per upload to control cost; ~$0.003 ceiling at default 20
+    public int MaxImagesPerDocument { get; set; } = 20;
+}

--- a/src/RagApi.Application/Services/DocumentService.cs
+++ b/src/RagApi.Application/Services/DocumentService.cs
@@ -35,10 +35,14 @@ public class DocumentService
     private readonly IVisionService? _visionService;
     private readonly IImageStore? _imageStore;
 
+    // Argha - 2026-03-18 - #52 - Maximum images to describe per document; caps GPT-4o-mini cost per upload
+    private readonly int _maxImagesPerDocument;
+
     // Argha - 2026-02-20 - Added IOptions<DocumentProcessingOptions> for configurable chunking
     // Argha - 2026-02-21 - Added IOptions<BatchUploadOptions> for batch upload settings
     // Argha - 2026-03-04 - #17 - Added IWorkspaceContext for per-request collection name
     // Argha - 2026-03-17 - #36 - Added optional IVisionService + IImageStore for multimodal ingestion
+    // Argha - 2026-03-18 - #52 - Added optional IOptions<VisionOptions> for cost guard (MaxImagesPerDocument)
     public DocumentService(
         IDocumentProcessor documentProcessor,
         IEmbeddingService embeddingService,
@@ -49,7 +53,8 @@ public class DocumentService
         IWorkspaceContext workspaceContext,
         IOptions<BatchUploadOptions>? batchOptions = null,
         IVisionService? visionService = null,
-        IImageStore? imageStore = null)
+        IImageStore? imageStore = null,
+        IOptions<VisionOptions>? visionOptions = null)
     {
         _documentProcessor = documentProcessor;
         _embeddingService = embeddingService;
@@ -62,6 +67,7 @@ public class DocumentService
         _batchOptions = batchOptions?.Value ?? new BatchUploadOptions();
         _visionService = visionService;
         _imageStore = imageStore;
+        _maxImagesPerDocument = visionOptions?.Value.MaxImagesPerDocument ?? 20;
     }
 
     /// <summary>
@@ -439,6 +445,15 @@ public class DocumentService
                 };
                 chunks.Add(chunk);
                 succeeded++;
+
+                // Argha - 2026-03-18 - #52 - Stop after limit to cap GPT-4o-mini cost per upload
+                if (succeeded >= _maxImagesPerDocument)
+                {
+                    _logger.LogInformation(
+                        "Vision pipeline: reached MaxImagesPerDocument limit ({Limit}) for document {DocumentId} — stopping",
+                        _maxImagesPerDocument, documentId);
+                    break;
+                }
             }
             catch (Exception ex)
             {

--- a/src/RagApi.Infrastructure/Configuration.cs
+++ b/src/RagApi.Infrastructure/Configuration.cs
@@ -50,11 +50,14 @@ public class VisionConfiguration
 {
     public const string SectionName = "Vision";
 
-    // Argha - 2026-03-16 - #32 - When false, NullVisionService is registered and image description is skipped
-    public bool Enabled { get; set; } = false;
+    // Argha - 2026-03-18 - #52 - Default true; NullVisionService is registered when Provider != OpenAI, so local Ollama dev is unaffected
+    public bool Enabled { get; set; } = true;
 
     // Argha - 2026-03-16 - #32 - gpt-4o-mini balances cost and quality for document image description
     public string Model { get; set; } = "gpt-4o-mini";
+
+    // Argha - 2026-03-18 - #52 - Cap GPT-4o-mini calls per upload; ~$0.003 ceiling at 20 images
+    public int MaxImagesPerDocument { get; set; } = 20;
 }
 
 /// <summary>

--- a/src/RagApi.Infrastructure/DependencyInjection.cs
+++ b/src/RagApi.Infrastructure/DependencyInjection.cs
@@ -58,6 +58,8 @@ public static class DependencyInjection
 
         // Argha - 2026-03-16 - #32 - Vision service: real impl only when enabled + provider is OpenAI
         services.Configure<VisionConfiguration>(configuration.GetSection(VisionConfiguration.SectionName));
+        // Argha - 2026-03-18 - #52 - Register Application-layer VisionOptions (MaxImagesPerDocument) from same section
+        services.Configure<VisionOptions>(configuration.GetSection(VisionOptions.SectionName));
         var visionConfig = configuration.GetSection(VisionConfiguration.SectionName)
             .Get<VisionConfiguration>() ?? new VisionConfiguration();
 

--- a/src/RagApi.Infrastructure/DocumentProcessing/DocumentProcessor.cs
+++ b/src/RagApi.Infrastructure/DocumentProcessing/DocumentProcessor.cs
@@ -326,10 +326,16 @@ public class DocumentProcessor : IDocumentProcessor
                 if (image.WidthInSamples < 100 || image.HeightInSamples < 100)
                     continue;
 
-                // Argha - 2026-03-16 - #34 - Determine filter; skip unsupported compression formats
+                // Argha - 2026-03-18 - #52 - JBIG2 has no viable free .NET decoder; log and skip
+                // CCITTFaxDecode is handled by PdfPig's internal CcittFaxDecodeFilter via TryGetPng()
                 var filterName = GetImageFilterName(image);
-                if (filterName is "JBIG2Decode" or "CCITTFaxDecode")
+                if (filterName is "JBIG2Decode")
+                {
+                    _logger.LogDebug(
+                        "Skipping JBIG2Decode image on page {Page} — no free .NET decoder available",
+                        pageNumber);
                     continue;
+                }
 
                 byte[] bytes;
                 string mimeType;

--- a/tests/RagApi.Tests/Unit/Infrastructure/DocumentProcessorTests.cs
+++ b/tests/RagApi.Tests/Unit/Infrastructure/DocumentProcessorTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using RagApi.Application.Interfaces;
+using RagApi.Application.Models;
 using RagApi.Infrastructure.DocumentProcessing;
 using UglyToad.PdfPig.Writer;
 
@@ -342,5 +343,13 @@ public class DocumentProcessorTests
         var result = await _sut.ExtractImagesAsync(stream, "application/pdf");
 
         result.Should().BeEmpty();
+    }
+
+    // Argha - 2026-03-18 - #52 - VisionOptions default cost-guard ceiling
+    [Fact]
+    public void VisionOptions_DefaultMaxImagesPerDocument_IsTwenty()
+    {
+        var options = new VisionOptions();
+        options.MaxImagesPerDocument.Should().Be(20);
     }
 }

--- a/tests/RagApi.Tests/Unit/Services/DocumentServiceTests.cs
+++ b/tests/RagApi.Tests/Unit/Services/DocumentServiceTests.cs
@@ -691,4 +691,41 @@ public class DocumentServiceVisionPipelineTests
         // Assert
         _imageStoreMock.Verify(s => s.DeleteByDocumentAsync(docId, It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    // Argha - 2026-03-18 - #52 - Cost guard: RunVisionPipelineAsync must stop after MaxImagesPerDocument
+    [Fact]
+    public async Task Upload_VisionEnabled_StopsDescribingAtMaxImagesPerDocument()
+    {
+        // Arrange: 25 images extracted, limit is 5
+        _visionMock.Setup(v => v.IsEnabled).Returns(true);
+        var sut = new DocumentService(
+            _processorMock.Object,
+            _embeddingMock.Object,
+            _vectorStoreMock.Object,
+            _loggerMock.Object,
+            _repositoryMock.Object,
+            Options.Create(new DocumentProcessingOptions()),
+            _workspaceContextMock.Object,
+            visionService: _visionMock.Object,
+            imageStore: _imageStoreMock.Object,
+            visionOptions: Options.Create(new VisionOptions { MaxImagesPerDocument = 5 }));
+
+        SetupTextPipeline();
+        var images = Enumerable.Range(0, 25).Select(i => MakeImage(i + 1, i)).ToList();
+        _processorMock.Setup(p => p.ExtractImagesAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(images);
+        _visionMock.Setup(v => v.DescribeImageAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("A diagram");
+        _imageStoreMock.Setup(s => s.SaveAsync(It.IsAny<DocumentImage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+        using var stream = new MemoryStream(new byte[10]);
+
+        // Act
+        await sut.UploadDocumentAsync(stream, "doc.pdf", "application/pdf");
+
+        // Assert: only 5 descriptions requested despite 25 images
+        _visionMock.Verify(
+            v => v.DescribeImageAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(5));
+    }
 }


### PR DESCRIPTION
## Summary

- **Root Cause 1:** `Vision:Enabled` was `false` by default, gating the entire image pipeline. Changed default to `true`. Local Ollama dev is unaffected — `NullVisionService` is registered when `AI:Provider != OpenAI`.
- **Root Cause 2:** `CCITTFaxDecode` images were skipped before `TryGetPng()` was attempted. Removed from early-exit; PdfPig's internal `CcittFaxDecodeFilter` handles decode. If it fails, the existing `null` guard skips gracefully.
- **Cost guard:** Added `Vision:MaxImagesPerDocument` (default `20`) — `RunVisionPipelineAsync` breaks after N successful descriptions (~$0.003 ceiling per upload).
- **JBIG2:** Retains skip but now logs at `Debug` instead of silently dropping. Tracked in #53 for future research.
- **Azure:** `Vision__Enabled=true` env var already added to Container App `rag-api` (no rebuild needed).

## Files changed

| File | Change |
|------|--------|
| `appsettings.json` | `Vision:Enabled` → `true`; added `MaxImagesPerDocument: 20` |
| `Configuration.cs` | Updated default; added `MaxImagesPerDocument` property |
| `VisionOptions.cs` _(new)_ | Application-layer options class for `MaxImagesPerDocument` |
| `DependencyInjection.cs` | Registers `VisionOptions` from `"Vision"` config section |
| `DocumentService.cs` | Injects `VisionOptions`; cost guard break in `RunVisionPipelineAsync` |
| `DocumentProcessor.cs` | Removed `CCITTFaxDecode` from skip; `LogDebug` for JBIG2 |
| `DocumentProcessorTests.cs` | New: `VisionOptions_DefaultMaxImagesPerDocument_IsTwenty` |
| `DocumentServiceTests.cs` | New: `Upload_VisionEnabled_StopsDescribingAtMaxImagesPerDocument` |

## Test plan

- [x] `dotnet build` — 0 errors
- [x] 330 unit tests pass (4 pre-existing PostgreSQL integration failures excluded)
- [x] 2 new tests added — cost guard and `VisionOptions` defaults
- [ ] Upload `en_US_BKS_9316_EN.pdf` to live API and verify `DocumentImages` table is populated

Fixes #52