### PR TITLE
Fix image metadata not persisted to vector store payload (#55)

### DIFF
--- a/src/RagApi.Infrastructure/DocumentProcessing/DocumentProcessor.cs
+++ b/src/RagApi.Infrastructure/DocumentProcessing/DocumentProcessor.cs
@@ -322,8 +322,8 @@ public class DocumentProcessor : IDocumentProcessor
 
             foreach (var image in page.GetImages())
             {
-                // Argha - 2026-03-16 - #34 - Skip decorative/icon images below minimum dimension threshold
-                if (image.WidthInSamples < 100 || image.HeightInSamples < 100)
+                // Argha - 2026-03-18 - #55 - Skip decorative/icon images below minimum dimension threshold (lowered from 100 to 50)
+                if (image.WidthInSamples < 50 || image.HeightInSamples < 50)
                     continue;
 
                 // Argha - 2026-03-18 - #52 - JBIG2 has no viable free .NET decoder; log and skip
@@ -423,9 +423,9 @@ public class DocumentProcessor : IDocumentProcessor
             if (bytes.Length > MaxBytes)
                 continue;
 
-            // Argha - 2026-03-16 - #35 - Apply 100x100 filter when dimensions are readable; include if unreadable
+            // Argha - 2026-03-18 - #55 - Apply 50x50 filter when dimensions are readable (lowered from 100); include if unreadable
             var (width, height) = TryGetImageDimensions(bytes, mimeType);
-            if (width.HasValue && height.HasValue && (width.Value < 100 || height.Value < 100))
+            if (width.HasValue && height.HasValue && (width.Value < 50 || height.Value < 50))
                 continue;
 
             results.Add(new ExtractedImage(

--- a/src/RagApi.Infrastructure/VectorStore/AzureAiSearchVectorStore.cs
+++ b/src/RagApi.Infrastructure/VectorStore/AzureAiSearchVectorStore.cs
@@ -29,6 +29,9 @@ public class AzureAiSearchVectorStore : IVectorStore
     private const string FieldContentType = "contentType";
     private const string FieldTags = "tags";
     private const string FieldEmbedding = "embedding";
+    // Argha - 2026-03-18 - #55 - Image metadata fields mirroring Qdrant payload schema
+    private const string FieldIsImage = "isImage";
+    private const string FieldImageId = "imageId";
 
     private readonly SearchIndexClient _indexClient;
     private readonly AzureAiSearchSettings _settings;
@@ -174,6 +177,9 @@ public class AzureAiSearchVectorStore : IVectorStore
         options.Select.Add(FieldFileName);
         options.Select.Add(FieldChunkIndex);
         options.Select.Add(FieldContentType);
+        // Argha - 2026-03-18 - #55 - Select image metadata fields so they are returned in results
+        options.Select.Add(FieldIsImage);
+        options.Select.Add(FieldImageId);
 
         var response = await searchClient.SearchAsync<SearchDocument>(
             searchText: query,
@@ -284,6 +290,9 @@ public class AzureAiSearchVectorStore : IVectorStore
                 new SimpleField(FieldEndPosition, SearchFieldDataType.Int32),
                 new SimpleField(FieldContentType, SearchFieldDataType.String),
                 new SimpleField(FieldTags, SearchFieldDataType.Collection(SearchFieldDataType.String)) { IsFilterable = true },
+                // Argha - 2026-03-18 - #55 - Image metadata fields
+                new SimpleField(FieldIsImage, SearchFieldDataType.String),
+                new SimpleField(FieldImageId, SearchFieldDataType.String),
                 new VectorSearchField(FieldEmbedding, _settings.EmbeddingDimension, "hnsw-profile")
             }
         };
@@ -317,6 +326,9 @@ public class AzureAiSearchVectorStore : IVectorStore
         options.Select.Add(FieldFileName);
         options.Select.Add(FieldChunkIndex);
         options.Select.Add(FieldContentType);
+        // Argha - 2026-03-18 - #55 - Select image metadata fields so they are returned in results
+        options.Select.Add(FieldIsImage);
+        options.Select.Add(FieldImageId);
 
         if (includeEmbedding)
             options.Select.Add(FieldEmbedding);
@@ -388,9 +400,12 @@ public class AzureAiSearchVectorStore : IVectorStore
             FileName = doc.GetString(FieldFileName) ?? string.Empty,
             ChunkIndex = doc.TryGetValue(FieldChunkIndex, out var ci) ? Convert.ToInt32(ci) : 0,
             Score = score,
+            // Argha - 2026-03-18 - #55 - Read image metadata back; guard against old index docs lacking the keys
             Metadata = new Dictionary<string, string>
             {
-                ["contentType"] = doc.GetString(FieldContentType) ?? string.Empty
+                ["contentType"] = doc.GetString(FieldContentType) ?? string.Empty,
+                ["isImage"] = doc.GetString(FieldIsImage) ?? "false",
+                ["imageId"] = doc.GetString(FieldImageId) ?? ""
             },
             Embedding = embedding
         };
@@ -408,6 +423,9 @@ public class AzureAiSearchVectorStore : IVectorStore
             [FieldStartPosition] = chunk.StartPosition,
             [FieldEndPosition] = chunk.EndPosition,
             [FieldContentType] = chunk.Metadata.GetValueOrDefault("contentType", ""),
+            // Argha - 2026-03-18 - #55 - Persist image metadata so search results can surface IsImage/ImageId
+            [FieldIsImage] = chunk.Metadata.GetValueOrDefault("isImage", "false"),
+            [FieldImageId] = chunk.Metadata.GetValueOrDefault("imageId", ""),
             [FieldTags] = chunk.Tags,
             [FieldEmbedding] = chunk.Embedding
         };

--- a/src/RagApi.Infrastructure/VectorStore/QdrantVectorStore.cs
+++ b/src/RagApi.Infrastructure/VectorStore/QdrantVectorStore.cs
@@ -189,6 +189,9 @@ public class QdrantVectorStore : IVectorStore
                     ["endPosition"] = chunk.EndPosition,
                     ["fileName"] = chunk.Metadata.GetValueOrDefault("fileName", ""),
                     ["contentType"] = chunk.Metadata.GetValueOrDefault("contentType", ""),
+                    // Argha - 2026-03-18 - #55 - Persist image metadata so search results can surface IsImage/ImageId
+                    ["isImage"] = chunk.Metadata.GetValueOrDefault("isImage", "false"),
+                    ["imageId"] = chunk.Metadata.GetValueOrDefault("imageId", ""),
                     // Argha - 2026-02-19 - Store tags as list payload for keyword filtering
                     ["tags"] = tagsValue
                 }
@@ -238,9 +241,12 @@ public class QdrantVectorStore : IVectorStore
                 Content = r.Payload["content"].StringValue,
                 Score = r.Score,
                 ChunkIndex = (int)r.Payload["chunkIndex"].IntegerValue,
+                // Argha - 2026-03-18 - #55 - Read image metadata back from payload; guard against old points lacking the keys
                 Metadata = new Dictionary<string, string>
                 {
-                    ["contentType"] = r.Payload["contentType"].StringValue
+                    ["contentType"] = r.Payload["contentType"].StringValue,
+                    ["isImage"] = r.Payload.TryGetValue("isImage", out var isImg1) ? isImg1.StringValue : "false",
+                    ["imageId"] = r.Payload.TryGetValue("imageId", out var imgId1) ? imgId1.StringValue : ""
                 }
             }).ToList();
         }
@@ -279,9 +285,12 @@ public class QdrantVectorStore : IVectorStore
                 Content = r.Payload["content"].StringValue,
                 Score = r.Score,
                 ChunkIndex = (int)r.Payload["chunkIndex"].IntegerValue,
+                // Argha - 2026-03-18 - #55 - Read image metadata back from payload; guard against old points lacking the keys
                 Metadata = new Dictionary<string, string>
                 {
-                    ["contentType"] = r.Payload["contentType"].StringValue
+                    ["contentType"] = r.Payload["contentType"].StringValue,
+                    ["isImage"] = r.Payload.TryGetValue("isImage", out var isImg2) ? isImg2.StringValue : "false",
+                    ["imageId"] = r.Payload.TryGetValue("imageId", out var imgId2) ? imgId2.StringValue : ""
                 },
                 // Argha - 2026-02-20 - Convert protobuf RepeatedField<float> to float[] for MMR
                 Embedding = r.Vectors?.Vector?.Data.ToArray()
@@ -365,9 +374,12 @@ public class QdrantVectorStore : IVectorStore
                 // Argha - 2026-02-20 - Score=1.0 placeholder; actual ranking done via RRF in RagService
                 Score = 1.0,
                 ChunkIndex = (int)r.Payload["chunkIndex"].IntegerValue,
+                // Argha - 2026-03-18 - #55 - Read image metadata back from payload; guard against old points lacking the keys
                 Metadata = new Dictionary<string, string>
                 {
-                    ["contentType"] = r.Payload["contentType"].StringValue
+                    ["contentType"] = r.Payload["contentType"].StringValue,
+                    ["isImage"] = r.Payload.TryGetValue("isImage", out var isImg3) ? isImg3.StringValue : "false",
+                    ["imageId"] = r.Payload.TryGetValue("imageId", out var imgId3) ? imgId3.StringValue : ""
                 }
             }).ToList();
         }

--- a/tests/RagApi.Tests/Unit/Infrastructure/DocumentProcessorTests.cs
+++ b/tests/RagApi.Tests/Unit/Infrastructure/DocumentProcessorTests.cs
@@ -177,18 +177,18 @@ public class DocumentProcessorTests
     }
 
     [Fact]
-    public async Task ExtractImagesAsync_DocxWithPng100x100_ReturnsOneImage()
+    public async Task ExtractImagesAsync_DocxWithPng50x50_ReturnsOneImage()
     {
-        // Argha - 2026-03-16 - #35 - 100x100 PNG meets minimum threshold; must be returned
-        var pngBytes = MakeFakePngHeader(100, 100);
+        // Argha - 2026-03-18 - #55 - 50x50 PNG meets minimum threshold (lowered from 100); must be returned
+        var pngBytes = MakeFakePngHeader(50, 50);
         using var stream = new MemoryStream(CreateDocxWithImage(pngBytes, "image/png"));
         var result = await _sut.ExtractImagesAsync(
             stream,
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
         result.Should().HaveCount(1);
         result[0].MimeType.Should().Be("image/png");
-        result[0].WidthPx.Should().Be(100);
-        result[0].HeightPx.Should().Be(100);
+        result[0].WidthPx.Should().Be(50);
+        result[0].HeightPx.Should().Be(50);
         result[0].PageNumber.Should().Be(0);
         result[0].ImageIndex.Should().Be(0);
     }
@@ -196,8 +196,8 @@ public class DocumentProcessorTests
     [Fact]
     public async Task ExtractImagesAsync_DocxWithSmallPng_IsSkipped()
     {
-        // Argha - 2026-03-16 - #35 - 50x50 PNG is below the 100x100 threshold; must be skipped
-        var smallPngBytes = MakeFakePngHeader(50, 50);
+        // Argha - 2026-03-18 - #55 - 49x49 PNG is below the 50x50 threshold; must be skipped
+        var smallPngBytes = MakeFakePngHeader(49, 49);
         using var stream = new MemoryStream(CreateDocxWithImage(smallPngBytes, "image/png"));
         var result = await _sut.ExtractImagesAsync(
             stream,
@@ -237,7 +237,7 @@ public class DocumentProcessorTests
     [Fact]
     public async Task ExtractImagesAsync_DocxWithMultipleImages_HasSequentialIndices()
     {
-        // Argha - 2026-03-16 - #35 - Two 100x100 PNGs must get ImageIndex 0 and 1 respectively
+        // Argha - 2026-03-18 - #55 - Two 100x100 PNGs (above the 50x50 threshold) must get ImageIndex 0 and 1 respectively
         var png1 = MakeFakePngHeader(100, 100);
         var png2 = MakeFakePngHeader(200, 200);
 


### PR DESCRIPTION
## Summary
- `isImage` and `imageId` from `chunk.Metadata` were silently dropped in `UpsertChunksAsync` in both `QdrantVectorStore` and `AzureAiSearchVectorStore` — only `fileName` and `contentType` were persisted
- All three result-mapping paths (`SearchAsync`, `SearchWithEmbeddingsAsync`, `KeywordSearchAsync`) only returned `contentType` in `Metadata`, so `RagService` always read `IsImage=false` / `ImageId=null`
- Images stored in `DocumentImages` table were never surfacing in chat results even though vision pipeline ran correctly
- Also lowers minimum image dimension filter from 100×100px to 50×50px in both PDF and DOCX extraction paths

## Test plan
- [ ] Build passes: 0 errors
- [ ] 330 tests pass (4 pre-existing PostgreSQL connection failures unrelated to this change)
- [ ] Re-upload a PDF with embedded images after deploy — verify chat sources include `isImage: true` entries
- [ ] Confirm image previews render in the UI sources panel

Fixes #55