### PR TITLE
Add Tesseract.NET OCR fallback for scanned PDFs (#51)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,12 @@ WORKDIR /app
 RUN adduser --disabled-password --gecos '' appuser
 
 # Argha - 2026-03-01 - install curl; required by HEALTHCHECK (not in aspnet base image)
-RUN apt-get update && apt-get install -y --no-install-recommends curl \
+# Argha - 2026-03-20 - #51 - install Tesseract + English tessdata for scanned PDF OCR fallback
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    tesseract-ocr \
+    tesseract-ocr-eng \
+    libtesseract-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Argha - 2026-03-01 - grant appuser write access to /app so SQLite can create ragapi.db at runtime

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 [![Deploy](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml/badge.svg)](https://github.com/Argha713/dotnet-rag-api/actions/workflows/deploy.yml)
 ![.NET](https://img.shields.io/badge/.NET-8.0-512BD4?style=flat&logo=dotnet)
 ![C#](https://img.shields.io/badge/C%23-12-239120?style=flat&logo=csharp)
-![Tests](https://img.shields.io/badge/tests-330%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-335%20passing-brightgreen)
 ![Phase](https://img.shields.io/badge/phase-14%20complete%20✅-brightgreen)
 ![License](https://img.shields.io/badge/License-MIT-green.svg)
 
@@ -28,6 +28,7 @@ A production-ready **Retrieval-Augmented Generation (RAG) API** built with **.NE
 
 ### Document Processing
 - **Multi-format ingestion** — PDF, DOCX, TXT, Markdown
+- **Scanned PDF OCR** — Tesseract.NET fallback extracts text from image-only (scanned) PDFs when no text layer is present
 - **Configurable chunking** — Fixed, Sentence, or Paragraph strategy per upload
 - **Batch upload** — Process 1–20 documents in a single request
 - **Document update & re-index** — Replace content in-place via `PUT /api/documents/{id}`; preserves ID and updates vector index

--- a/src/RagApi.Api/appsettings.json
+++ b/src/RagApi.Api/appsettings.json
@@ -127,5 +127,11 @@
     "Enabled": true,
     "Model": "gpt-4o-mini",
     "MaxImagesPerDocument": 20
+  },
+
+  "Ocr": {
+    "Enabled": false,
+    "TessDataPath": "/usr/share/tesseract-ocr/5/tessdata",
+    "Language": "eng"
   }
 }

--- a/src/RagApi.Application/Interfaces/IOcrService.cs
+++ b/src/RagApi.Application/Interfaces/IOcrService.cs
@@ -1,0 +1,16 @@
+namespace RagApi.Application.Interfaces;
+
+/// <summary>
+/// OCR service for extracting text from image bytes.
+/// Used as a fallback when PDF text extraction yields no text (scanned documents).
+/// </summary>
+public interface IOcrService
+{
+    bool IsEnabled { get; }
+
+    /// <summary>
+    /// Runs character recognition on a single image and returns the extracted text.
+    /// Returns an empty string when recognition yields no output or the service is disabled.
+    /// </summary>
+    Task<string> RecognizeTextAsync(byte[] imageBytes, CancellationToken cancellationToken = default);
+}

--- a/src/RagApi.Infrastructure/AI/NullOcrService.cs
+++ b/src/RagApi.Infrastructure/AI/NullOcrService.cs
@@ -1,0 +1,14 @@
+using RagApi.Application.Interfaces;
+
+namespace RagApi.Infrastructure.AI;
+
+/// <summary>
+/// No-op OCR service registered when OCR is disabled or not configured.
+/// </summary>
+internal sealed class NullOcrService : IOcrService
+{
+    public bool IsEnabled => false;
+
+    public Task<string> RecognizeTextAsync(byte[] imageBytes, CancellationToken cancellationToken = default)
+        => Task.FromResult(string.Empty);
+}

--- a/src/RagApi.Infrastructure/AI/OcrOptions.cs
+++ b/src/RagApi.Infrastructure/AI/OcrOptions.cs
@@ -1,0 +1,11 @@
+namespace RagApi.Infrastructure.AI;
+
+public class OcrOptions
+{
+    public bool Enabled { get; set; } = false;
+
+    // Default is the Debian/Ubuntu path after: apt-get install tesseract-ocr tesseract-ocr-eng
+    public string TessDataPath { get; set; } = "/usr/share/tesseract-ocr/5/tessdata";
+
+    public string Language { get; set; } = "eng";
+}

--- a/src/RagApi.Infrastructure/AI/TesseractOcrService.cs
+++ b/src/RagApi.Infrastructure/AI/TesseractOcrService.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RagApi.Application.Interfaces;
+using Tesseract;
+
+namespace RagApi.Infrastructure.AI;
+
+/// <summary>
+/// OCR service backed by Tesseract.NET.
+/// Registered as Singleton — TesseractEngine is thread-safe for read operations.
+/// Requires tessdata files and native Tesseract libraries (see Dockerfile).
+/// </summary>
+internal sealed class TesseractOcrService : IOcrService, IDisposable
+{
+    private readonly TesseractEngine _engine;
+    private readonly ILogger<TesseractOcrService> _logger;
+
+    public bool IsEnabled => true;
+
+    public TesseractOcrService(IOptions<OcrOptions> options, ILogger<TesseractOcrService> logger)
+    {
+        _logger = logger;
+        var opts = options.Value;
+        _engine = new TesseractEngine(opts.TessDataPath, opts.Language, EngineMode.Default);
+    }
+
+    public Task<string> RecognizeTextAsync(byte[] imageBytes, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var pix = Pix.LoadFromMemory(imageBytes);
+            using var page = _engine.Process(pix);
+            var text = page.GetText() ?? string.Empty;
+            return Task.FromResult(text.Trim());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Tesseract OCR failed for image ({Bytes} bytes); skipping", imageBytes.Length);
+            return Task.FromResult(string.Empty);
+        }
+    }
+
+    public void Dispose() => _engine.Dispose();
+}

--- a/src/RagApi.Infrastructure/DependencyInjection.cs
+++ b/src/RagApi.Infrastructure/DependencyInjection.cs
@@ -89,6 +89,14 @@ public static class DependencyInjection
             services.AddSingleton<IVectorStore, QdrantVectorStore>();
         }
 
+        // Argha - 2026-03-20 - #51 - Register OCR service; NullOcrService when disabled so DocumentProcessor always has a dependency
+        services.Configure<OcrOptions>(configuration.GetSection("Ocr"));
+        var ocrOptions = configuration.GetSection("Ocr").Get<OcrOptions>() ?? new OcrOptions();
+        if (ocrOptions.Enabled)
+            services.AddSingleton<IOcrService, TesseractOcrService>();
+        else
+            services.AddSingleton<IOcrService, NullOcrService>();
+
         // Register document processor
         services.AddSingleton<IDocumentProcessor, DocumentProcessor>();
 

--- a/src/RagApi.Infrastructure/DocumentProcessing/DocumentProcessor.cs
+++ b/src/RagApi.Infrastructure/DocumentProcessing/DocumentProcessor.cs
@@ -8,6 +8,8 @@ using RagApi.Domain.Entities;
 using Microsoft.Extensions.Logging;
 using System.Text;
 using System.Text.RegularExpressions;
+// Argha - 2026-03-20 - #51 - IOcrService used for OCR fallback on scanned PDFs
+using Page = UglyToad.PdfPig.Content.Page;
 
 namespace RagApi.Infrastructure.DocumentProcessing;
 
@@ -17,6 +19,8 @@ namespace RagApi.Infrastructure.DocumentProcessing;
 public class DocumentProcessor : IDocumentProcessor
 {
     private readonly ILogger<DocumentProcessor> _logger;
+    // Argha - 2026-03-20 - #51 - OCR service injected for scanned PDF fallback; NullOcrService when disabled
+    private readonly IOcrService _ocrService;
 
     private static readonly IReadOnlyList<string> _supportedTypes = new[]
     {
@@ -26,9 +30,10 @@ public class DocumentProcessor : IDocumentProcessor
         "text/markdown"
     };
 
-    public DocumentProcessor(ILogger<DocumentProcessor> logger)
+    public DocumentProcessor(ILogger<DocumentProcessor> logger, IOcrService ocrService)
     {
         _logger = logger;
+        _ocrService = ocrService;
     }
 
     public IReadOnlyList<string> SupportedContentTypes => _supportedTypes;
@@ -40,9 +45,10 @@ public class DocumentProcessor : IDocumentProcessor
 
     public async Task<string> ExtractTextAsync(Stream fileStream, string contentType, CancellationToken cancellationToken = default)
     {
+        // Argha - 2026-03-20 - #51 - PDF branch is now async to support OCR fallback
         return contentType.ToLowerInvariant() switch
         {
-            "application/pdf" => ExtractFromPdf(fileStream),
+            "application/pdf" => await ExtractFromPdfAsync(fileStream, cancellationToken),
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => ExtractFromDocx(fileStream),
             "text/plain" or "text/markdown" => await ExtractFromTextAsync(fileStream, cancellationToken),
             _ => throw new NotSupportedException($"Content type '{contentType}' is not supported")
@@ -253,19 +259,76 @@ public class DocumentProcessor : IDocumentProcessor
         return text.Trim();
     }
 
-    private string ExtractFromPdf(Stream fileStream)
+    // Argha - 2026-03-20 - #51 - Async; falls back to OCR when PdfPig yields no text (scanned PDFs)
+    private async Task<string> ExtractFromPdfAsync(Stream fileStream, CancellationToken cancellationToken)
     {
-        var textBuilder = new StringBuilder();
-
         using var document = PdfDocument.Open(fileStream);
-        foreach (var page in document.GetPages())
+        var pages = document.GetPages().ToList();
+
+        var textBuilder = new StringBuilder();
+        foreach (var page in pages)
         {
-            var pageText = page.Text;
-            textBuilder.AppendLine(pageText);
+            textBuilder.AppendLine(page.Text);
             textBuilder.AppendLine(); // Add paragraph break between pages
         }
 
-        return textBuilder.ToString();
+        var text = textBuilder.ToString();
+
+        // Argha - 2026-03-20 - #51 - If PdfPig found no text and OCR is enabled, extract page images and OCR them
+        if (!string.IsNullOrWhiteSpace(text) || !_ocrService.IsEnabled)
+            return text;
+
+        _logger.LogInformation("PDF text layer empty; running OCR fallback via Tesseract");
+        return await OcrPdfPagesAsync(pages, cancellationToken);
+    }
+
+    // Argha - 2026-03-20 - #51 - Extracts embedded images from each page and runs OCR; concatenates results
+    private async Task<string> OcrPdfPagesAsync(List<Page> pages, CancellationToken cancellationToken)
+    {
+        var ocrBuilder = new StringBuilder();
+
+        for (var i = 0; i < pages.Count; i++)
+        {
+            var page = pages[i];
+            var pageNumber = i + 1;
+            var pageHadText = false;
+
+            foreach (var image in page.GetImages())
+            {
+                // Argha - 2026-03-20 - #51 - No dimension filter here; the full page image is what we want
+                var filterName = GetImageFilterName(image);
+
+                // Argha - 2026-03-20 - #51 - JBIG2 has no free decoder; skip (see also ExtractImagesAsync)
+                if (filterName is "JBIG2Decode")
+                    continue;
+
+                byte[] bytes;
+                if (filterName == "DCTDecode")
+                {
+                    bytes = image.RawBytes.ToArray();
+                }
+                else
+                {
+                    if (!image.TryGetPng(out var png) || png is null)
+                        continue;
+                    bytes = png;
+                }
+
+                var pageText = await _ocrService.RecognizeTextAsync(bytes, cancellationToken);
+                if (!string.IsNullOrWhiteSpace(pageText))
+                {
+                    ocrBuilder.AppendLine(pageText);
+                    pageHadText = true;
+                }
+            }
+
+            if (pageHadText)
+                ocrBuilder.AppendLine(); // paragraph break between pages
+            else
+                _logger.LogDebug("OCR found no text on page {PageNumber}", pageNumber);
+        }
+
+        return ocrBuilder.ToString();
     }
 
     private string ExtractFromDocx(Stream fileStream)

--- a/src/RagApi.Infrastructure/RagApi.Infrastructure.csproj
+++ b/src/RagApi.Infrastructure/RagApi.Infrastructure.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.8" />
     <!-- Argha - 2026-02-21 - Azure AI Search vector store provider  -->
     <PackageReference Include="Azure.Search.Documents" Version="11.6.0" />
+    <PackageReference Include="Tesseract" Version="5.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/RagApi.Tests/Unit/Infrastructure/ChunkingStrategyTests.cs
+++ b/tests/RagApi.Tests/Unit/Infrastructure/ChunkingStrategyTests.cs
@@ -19,7 +19,8 @@ public class ChunkingStrategyTests
 
     public ChunkingStrategyTests()
     {
-        _processor = new DocumentProcessor(Mock.Of<ILogger<DocumentProcessor>>());
+        // Argha - 2026-03-20 - #51 - OCR service required by updated ctor; disabled for chunking tests
+        _processor = new DocumentProcessor(Mock.Of<ILogger<DocumentProcessor>>(), Mock.Of<IOcrService>());
     }
 
     // --- Fixed (regression) ---

--- a/tests/RagApi.Tests/Unit/Infrastructure/DocumentProcessorTests.cs
+++ b/tests/RagApi.Tests/Unit/Infrastructure/DocumentProcessorTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using RagApi.Application.Interfaces;
 using RagApi.Application.Models;
+using RagApi.Infrastructure.AI;
 using RagApi.Infrastructure.DocumentProcessing;
 using UglyToad.PdfPig.Writer;
 
@@ -19,7 +20,8 @@ public class DocumentProcessorTests
     public DocumentProcessorTests()
     {
         var loggerMock = new Mock<ILogger<DocumentProcessor>>();
-        _sut = new DocumentProcessor(loggerMock.Object);
+        // Argha - 2026-03-20 - #51 - NullOcrService (OCR disabled) for non-OCR tests
+        _sut = new DocumentProcessor(loggerMock.Object, Mock.Of<IOcrService>());
     }
 
     [Theory]
@@ -351,5 +353,101 @@ public class DocumentProcessorTests
     {
         var options = new VisionOptions();
         options.MaxImagesPerDocument.Should().Be(20);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Argha - 2026-03-20 - #51 - OCR fallback tests
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void NullOcrService_IsEnabled_ReturnsFalse()
+    {
+        var svc = new NullOcrService();
+        svc.IsEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task NullOcrService_RecognizeTextAsync_ReturnsEmpty()
+    {
+        var svc = new NullOcrService();
+        var result = await svc.RecognizeTextAsync(new byte[] { 1, 2, 3 });
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_PdfWithTextLayer_OcrNotCalled()
+    {
+        // Arrange: build a text PDF; OCR service should never be called
+        var ocrMock = new Mock<IOcrService>();
+        ocrMock.Setup(s => s.IsEnabled).Returns(true);
+
+        var logger = new Mock<ILogger<DocumentProcessor>>();
+        var sut = new DocumentProcessor(logger.Object, ocrMock.Object);
+
+        var builder = new PdfDocumentBuilder();
+        var page = builder.AddPage(UglyToad.PdfPig.Content.PageSize.A4);
+        // PdfPig requires a font to add text; use the standard Helvetica built-in
+        var font = builder.AddStandard14Font(UglyToad.PdfPig.Fonts.Standard14Fonts.Standard14Font.Helvetica);
+        page.AddText("Hello world", 12, new UglyToad.PdfPig.Core.PdfPoint(50, 700), font);
+        var pdfBytes = builder.Build();
+
+        using var stream = new MemoryStream(pdfBytes);
+
+        // Act
+        var result = await sut.ExtractTextAsync(stream, "application/pdf");
+
+        // Assert: OCR was never invoked
+        ocrMock.Verify(s => s.RecognizeTextAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        result.Should().Contain("Hello world");
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_EmptyPdf_OcrDisabled_ReturnsEmpty()
+    {
+        // Arrange: text-layer-empty PDF with OCR disabled (NullOcrService)
+        var ocrMock = new Mock<IOcrService>();
+        ocrMock.Setup(s => s.IsEnabled).Returns(false);
+
+        var logger = new Mock<ILogger<DocumentProcessor>>();
+        var sut = new DocumentProcessor(logger.Object, ocrMock.Object);
+
+        var builder = new PdfDocumentBuilder();
+        builder.AddPage(UglyToad.PdfPig.Content.PageSize.A4); // no text, no images
+        var pdfBytes = builder.Build();
+
+        using var stream = new MemoryStream(pdfBytes);
+
+        // Act — should not throw even though text is empty
+        var result = await sut.ExtractTextAsync(stream, "application/pdf");
+
+        // Assert: OCR not attempted
+        ocrMock.Verify(s => s.RecognizeTextAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        result.Trim().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_EmptyPdf_OcrEnabled_NoImages_ReturnsEmpty()
+    {
+        // Arrange: empty PDF (no text, no images), OCR enabled but nothing to OCR
+        var ocrMock = new Mock<IOcrService>();
+        ocrMock.Setup(s => s.IsEnabled).Returns(true);
+        ocrMock.Setup(s => s.RecognizeTextAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync("should not be called");
+
+        var logger = new Mock<ILogger<DocumentProcessor>>();
+        var sut = new DocumentProcessor(logger.Object, ocrMock.Object);
+
+        var builder = new PdfDocumentBuilder();
+        builder.AddPage(UglyToad.PdfPig.Content.PageSize.A4);
+        var pdfBytes = builder.Build();
+
+        using var stream = new MemoryStream(pdfBytes);
+
+        // Act
+        var result = await sut.ExtractTextAsync(stream, "application/pdf");
+
+        // Assert: OCR called 0 times (no embedded images on the page)
+        ocrMock.Verify(s => s.RecognizeTextAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        result.Trim().Should().BeEmpty();
     }
 }


### PR DESCRIPTION
## Summary

- Scanned PDFs (image-only, no embedded text layer) previously failed with HTTP 400. This adds Tesseract.NET as an OCR fallback inside `DocumentProcessor`.
- When PdfPig's text extraction returns empty, the processor extracts embedded page images via `page.GetImages()` and runs Tesseract character recognition per image.
- OCR is opt-in via `Ocr:Enabled` config (default `false`) — local dev and existing deployments are unaffected until explicitly enabled.
- `IVisionService` pattern followed: `IOcrService` interface + `NullOcrService` (disabled) + `TesseractOcrService` (Singleton).
- Dockerfile installs `tesseract-ocr`, `tesseract-ocr-eng`, `libtesseract-dev` in the runtime image; enable in Azure via `Ocr__Enabled=true` env var.

## Test plan

- [ ] CI passes (build + 335 tests)
- [ ] `NullOcrService.IsEnabled` returns false
- [ ] `NullOcrService.RecognizeTextAsync` returns empty string
- [ ] PDF with text layer — OCR service never called
- [ ] Empty PDF + OCR disabled — no exception, returns empty
- [ ] Empty PDF + OCR enabled + no images — OCR not called, returns empty

Closes #51