### PR TITLE
Fix 429 rate limit + hero (orb/greeting/cards) never visible

### DIFF
--- a/src/RagApi.BlazorUI/Pages/Chat.razor
+++ b/src/RagApi.BlazorUI/Pages/Chat.razor
@@ -43,7 +43,8 @@ else
     @* ── Left sidebar: conversation list ── *@
     <div class="chat-sidebar">
 
-        <button class="btn-primary-modern w-100" @onclick="CreateNewConversationAsync" disabled="@_isStreaming">
+        @* Argha - 2026-03-20 - #61 - Reset to hero state; conversation is lazily created on first message send *@
+        <button class="btn-primary-modern w-100" @onclick="ResetToHeroAsync" disabled="@_isStreaming">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
                 <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
             </svg>
@@ -511,6 +512,17 @@ else
     {
         _inputText = prompt;
         StateHasChanged();
+    }
+
+    // Argha - 2026-03-20 - #61 - Reset to hero (empty) state; conversation created lazily on first send
+    private Task ResetToHeroAsync()
+    {
+        _activeConvId = Guid.Empty;
+        _messages = new();
+        _inputText = string.Empty;
+        _errorMessage = string.Empty;
+        StateHasChanged();
+        return Task.CompletedTask;
     }
 
     // Argha - 2026-03-15 - #24 - Commented out: server is now source of truth; localStorage no longer persisted

--- a/src/RagApi.BlazorUI/wwwroot/css/app.css
+++ b/src/RagApi.BlazorUI/wwwroot/css/app.css
@@ -135,11 +135,12 @@ html, body {
 /* .app-footer { ... } */
 
 /* ─── Chat layout ─────────────────────────────────────────────────── */
+/* Argha - 2026-03-20 - #61 - overflow: visible so orb can extend above the layout boundary */
 .chat-layout {
     display: flex;
     flex: 1;
     min-height: 0;
-    overflow: hidden;
+    overflow: visible;
 }
 
 /* Conversation sidebar */
@@ -213,15 +214,19 @@ html, body {
 }
 
 /* Chat panel */
+/* Argha - 2026-03-20 - #61 - Changed overflow: hidden → visible so the orb (top: -140px) is not clipped */
 .chat-panel {
     flex: 1;
+    min-width: 0;
+    min-height: 0;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    overflow: visible;
 }
 
 /* ─── Chat hero (empty state — orb + greeting + cards + input) ─────── */
 /* Argha - 2026-03-20 - #59 - Hero section shown when no conversation is active */
+/* Argha - 2026-03-20 - #61 - overflow: visible so the orb (position: absolute; top: -140px) is not clipped */
 .chat-hero {
     flex: 1;
     display: flex;
@@ -230,7 +235,7 @@ html, body {
     justify-content: center;
     padding: var(--space-8);
     position: relative;
-    overflow: hidden;
+    overflow: visible;
     gap: var(--space-6);
 }
 


### PR DESCRIPTION
## Summary

- **Rate limit raised** — `RateLimit__PermitLimit` updated from `10` → `60` in Azure Container App via `az containerapp update` (immediate, no deploy needed). New revision: `rag-api--0000020`
- **New Conversation → hero state** — button no longer immediately creates a server-side session; instead resets `_activeConvId = Guid.Empty` so the hero (orb + greeting + cards) is always visible when starting fresh. Conversation created lazily on first message send.
- **Orb no longer clipped** — removed `overflow: hidden` from `.chat-panel`, `.chat-hero`, and `.chat-layout` so the orb at `top: -140px` renders above the panel boundary instead of being cut off.

## Root causes

| Symptom | Cause |
|---|---|
| 429 on /api/documents, /api/conversations | `RateLimit__PermitLimit=10` per 60 s — exhausted by normal page load |
| Orb/greeting/cards never seen | Existing conversations auto-selected on load; "New Conversation" also bypassed hero via immediate session creation |
| Top of orb clipped | `overflow: hidden` on `.chat-panel` (and ancestors) clipped `position: absolute; top: -140px` |

## Test plan

- [x] `dotnet build RagApi.sln` — 0 errors
- [ ] 429 errors gone after page refresh (rate limit now 60/min)
- [ ] Clicking "New Conversation" shows the orb hero, not blank conversation
- [ ] Full orb sphere visible (not clipped at top)
- [ ] Parallax responds to mouse movement
- [ ] Greeting shows workspace name
- [ ] Quick-action cards pre-fill textarea
- [ ] Sending from hero input auto-creates conversation and transitions to messages view

Fixes #61